### PR TITLE
Remove auto-service processor leakage.

### DIFF
--- a/formula-compiler/build.gradle
+++ b/formula-compiler/build.gradle
@@ -44,8 +44,8 @@ dependencies {
     implementation libraries.arrow.core
     implementation libraries.rxrelays
 
-    def autoServiceVersion = '1.0-rc4'
-    implementation "com.google.auto.service:auto-service:$autoServiceVersion"
+    def autoServiceVersion = "1.0-rc5"
+    compileOnly "com.google.auto.service:auto-service-annotations:$autoServiceVersion"
     kapt "com.google.auto.service:auto-service:$autoServiceVersion"
 
     kaptTest files('build/libs/formula-compiler.jar')


### PR DESCRIPTION
Using `compileOnly` + annotations only to avoid leaking the actual AutoServiceProcessor. 