### PR TITLE
Allow to use default back behavior.

### DIFF
--- a/docs/Integration.md
+++ b/docs/Integration.md
@@ -319,11 +319,19 @@ To override how the back button works for a particular navigation destination, y
 
 ```kotlin
 data class FormRenderModel(
+    private val confirmBeforeExiting: Boolean,
     private val confirmUserWantsToExit: () -> Unit
 ): BackCallback {
 
-    fun onBackPressed() {
-        confirmUserWantsToExit()
+    fun onBackPressed(): Boolean {
+        // Check if we need to override back handling
+        if (confirmBeforeExiting) {
+            confirmUserWantsToExit()
+            return true
+        }
+        
+        // Use default behavior (which closes the screen)
+        return false 
     }
 }
 ```

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -130,8 +130,9 @@ class FragmentFlowRenderViewTest {
 
         val contract = TestContractWithId(1)
         sendStateUpdate(contract, object : BackCallback {
-            override fun onBackPressed() {
+            override fun onBackPressed(): Boolean {
                 backPressed += 1
+                return true
             }
         })
 

--- a/formula-android/src/main/java/com/instacart/formula/integration/BackCallback.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/BackCallback.kt
@@ -5,5 +5,9 @@ package com.instacart.formula.integration
  * handles back presses.
  */
 interface BackCallback {
-    fun onBackPressed()
+
+    /**
+     * Returns true if it handles back press.
+     */
+    fun onBackPressed(): Boolean
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -119,12 +119,7 @@ class FragmentFlowRenderView(
         // TODO: only visible fragments should handle back presses.
         // currentFragmentRenderModel might not be currently visible fragment.
         val state = currentFragmentRenderModel
-        if (state is BackCallback) {
-            state.onBackPressed()
-            return true
-        }
-
-        return false
+        return state is BackCallback && state.onBackPressed()
     }
 
     /**


### PR DESCRIPTION
Change `BackCallback` to return `Boolean`. This will enable us to easily use the default back button behavior which closes the screen.

```kotlin
fun onBackPressed(): Boolean {
    if (confirmBeforeExiting) {
         showConfirmationDialog()
         return true
    }

    // This will default to closing the screen
    return false
}
```