### PR TITLE
[exploration] activity state persistence API.

### DIFF
--- a/formula-android-tests/src/test/java/com/instacart/formula/android/FormulaPersistenceTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/android/FormulaPersistenceTest.kt
@@ -1,0 +1,66 @@
+package com.instacart.formula.android
+
+import android.os.Parcelable
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.rules.ActivityScenarioRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.FormulaAndroid
+import com.instacart.formula.TestFormulaRule
+import com.instacart.formula.integration.FormulaAppCompatActivity
+import com.jakewharton.rxrelay2.PublishRelay
+import kotlinx.android.parcel.Parcelize
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FormulaPersistenceTest {
+
+    class TestActivity : FormulaAppCompatActivity()
+
+    @Parcelize
+    data class MyState(val value: String) : Parcelable
+
+    private var restoredState: MyState? = null
+    private lateinit var valueRelay: PublishRelay<Int>
+
+    private val formulaRule = TestFormulaRule(
+        initFormula = { app ->
+            valueRelay = PublishRelay.create()
+
+            FormulaAndroid.init(app) {
+                activity<TestActivity> {
+                    val myPersistedState = withState<MyState>()
+                    restoredState = myPersistedState.current()
+
+                    store(
+                        streams = {
+                            valueRelay.subscribe { myPersistedState.save(MyState(value = "$it")) }
+                        },
+                        contracts = {
+                        }
+                    )
+                }
+            }
+        })
+
+    private val activityRule = ActivityScenarioRule(TestActivity::class.java)
+
+    @get:Rule val rule = RuleChain.outerRule(formulaRule).around(activityRule)
+    lateinit var scenario: ActivityScenario<TestActivity>
+
+    @Before fun setup() {
+        scenario = activityRule.scenario
+    }
+
+    @Test fun `process death`() {
+        valueRelay.accept(100)
+
+        formulaRule.fakeProcessDeath()
+
+        assertThat(restoredState).isEqualTo(MyState("100"))
+    }
+}

--- a/formula-android/src/main/java/com/instacart/formula/android/persistence/PersistedState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/persistence/PersistedState.kt
@@ -1,0 +1,16 @@
+package com.instacart.formula.android.persistence
+
+import android.os.Parcelable
+
+interface PersistedState<State : Parcelable> {
+
+    /**
+     * Gets the current [State] value.
+     */
+    fun current(): State?
+
+    /**
+     * Sets the latest [State] value that will be persisted across process death.
+     */
+    fun save(state: State?)
+}

--- a/formula-android/src/main/java/com/instacart/formula/integration/ActivityStoreContext.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/ActivityStoreContext.kt
@@ -1,8 +1,10 @@
 package com.instacart.formula.integration
 
+import android.os.Parcelable
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import com.instacart.formula.activity.ActivityResult
+import com.instacart.formula.android.persistence.PersistedState
 import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentFlowState
 import com.instacart.formula.fragment.FragmentFlowStore
@@ -12,6 +14,7 @@ import com.jakewharton.rxrelay2.PublishRelay
 import io.reactivex.Observable
 import io.reactivex.disposables.Disposable
 import io.reactivex.functions.BiFunction
+import kotlin.reflect.KClass
 
 /**
  * This class provides context within which you can create [ActivityStore]. It provides
@@ -28,6 +31,12 @@ class ActivityStoreContext<Activity : FragmentActivity>(
 
     internal fun onActivityResult(result: ActivityResult) {
         activityResultRelay.accept(result)
+    }
+
+    inline fun <reified State : Parcelable> withState(): PersistedState<State> = withState(State::class)
+
+    fun <State : Parcelable> withState(type: KClass<State>): PersistedState<State> {
+        return TODO()
     }
 
     /**
@@ -75,7 +84,7 @@ class ActivityStoreContext<Activity : FragmentActivity>(
         onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null,
         streams: (StreamConfigurator<Activity>.() -> Disposable)? = null,
         contracts: FragmentFlowStore
-    ) : ActivityStore<Activity> {
+    ): ActivityStore<Activity> {
         val streamStart = createStreamStartFunction(streams)
 
         return ActivityStore(
@@ -106,7 +115,7 @@ class ActivityStoreContext<Activity : FragmentActivity>(
         noinline onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null,
         noinline streams: (StreamConfigurator<Activity>.() -> Disposable)? = null,
         crossinline contracts: FragmentBindingBuilder<Unit>.() -> Unit
-    ) : ActivityStore<Activity> {
+    ): ActivityStore<Activity> {
         return store(
             configureActivity = configureActivity,
             onRenderFragmentState = onRenderFragmentState,
@@ -122,7 +131,7 @@ class ActivityStoreContext<Activity : FragmentActivity>(
     inline fun <Component> contracts(
         rootComponent: Component,
         crossinline contracts: FragmentBindingBuilder<Component>.() -> Unit
-    ) : FragmentFlowStore {
+    ): FragmentFlowStore {
         return FragmentFlowStore.init(rootComponent, contracts)
     }
 

--- a/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
@@ -13,6 +13,7 @@ class TodoApp : Application() {
         FormulaAndroid.init(this) {
             activity<TodoActivity> {
                 val component = TodoAppComponent()
+
                 store(
                     contracts = contracts(component) {
                         bind(TaskListContract::class) { component, key ->


### PR DESCRIPTION
I'm thinking to provide an easy way to persist activity state from Formula.

This mechanism would work only for `Parcelable` types.
```kotlin
@Parcelize
data class MyState(val value: String) : Parcelable
```

The actual API would be
```kotlin
activity<MyActivity> {
    val myState = withState<MyState>()

    // This returns a current value, you can use it to initialize the store 
    myState.currentValue()

    // Any time state changes, you can update the value.
    myState.save(MyState("new value"))    

    store(
        streams = {
            // As part of the state updates, you can save the new state value.
            // Formula will automatically persist it across process death.
            stateStream.subscribe {
                myState.save(it)     
            }     
        }
    )
}
```

You don't need to worry about `Bundle` keys, you can just grab multiple states
```kotlin
val styleState = withState<AppStyles>()
val cartState = withState<CartState>()
val tabState = withState<TabState>()
```