### PR TITLE
Updating processor internals to make them more robust.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/internal/ProcessorManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ProcessorManager.kt
@@ -74,7 +74,9 @@ class ProcessorManager<Input, State, Effect>(
 
         val result = formula.evaluate(input, state, context)
         val frame = Frame(result.updates, context.children)
+        updateManager.updateEventListeners(frame.updates)
         this.frame = frame
+
 
         // Set pending removal of children.
         val childIterator = children.iterator()
@@ -93,17 +95,34 @@ class ProcessorManager<Input, State, Effect>(
         return result
     }
 
-    private fun processUpdates(currentTransition: Long): Boolean {
+    private fun terminateOldUpdates(currentTransition: Long): Boolean {
         val newFrame = frame ?: throw IllegalStateException("call evaluate before calling nextFrame()")
 
-        // Update parent workers so they are ready to handle events
-        if (updateManager.updateConnections(newFrame.updates, currentTransition)) {
+        if (updateManager.terminateOld(newFrame.updates, currentTransition)) {
             return true
         }
 
         // Step through children frames
         children.forEach {
-            if (it.value.processUpdates(currentTransition)) {
+            if (it.value.terminateOldUpdates(currentTransition)) {
+                return true
+            }
+        }
+
+        return false
+    }
+
+    private fun startNewUpdates(currentTransition: Long): Boolean {
+        val newFrame = frame ?: throw IllegalStateException("call evaluate before calling nextFrame()")
+
+        // Update parent workers so they are ready to handle events
+        if (updateManager.startNew(newFrame.updates, currentTransition)) {
+            return true
+        }
+
+        // Step through children frames
+        children.forEach {
+            if (it.value.startNewUpdates(currentTransition)) {
                 return true
             }
         }
@@ -153,7 +172,11 @@ class ProcessorManager<Input, State, Effect>(
      * Returns true if has transition while moving to next frame.
      */
     fun nextFrame(currentTransition: Long): Boolean {
-        if (processUpdates(currentTransition)) {
+        if (terminateOldUpdates(currentTransition)) {
+            return true
+        }
+
+        if (startNewUpdates(currentTransition)) {
             return true
         }
 


### PR DESCRIPTION
To make things more robust and clear:
1. Before doing any processing, we update all event listeners to point to the latest state.
2. Separate termination of old update streams and initialization of new ones.