### PR TITLE
Fix an issue where context.key was not resetting state correctly.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
 # Changelog
+
+## [0.5.2-alpha2] - October 22, 2019
+- Bugfix: Fix `context.key` exit scope logic.
+
 ## [0.5.2-alpha1] - October 22, 2019
 - **Breaking**: Replacing `message` API with post transition side-effect block. [#115](https://github.com/instacart/formula/pull/115)
 

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -10,6 +10,7 @@ internal class ScopedCallbacks private constructor(
 
     private val callbacks: SingleRequestMap<Any, Callbacks> = mutableMapOf()
 
+    private var lastCallbacks: Callbacks? = null
     private var lastKey: Any? = null
     private var currentKey: Any = rootKey
     private var current: Callbacks? = null
@@ -28,8 +29,12 @@ internal class ScopedCallbacks private constructor(
 
     fun enterScope(key: Any) {
         ensureNotRunning()
+        if (currentKey != rootKey) {
+            throw IllegalStateException("Nested scopes are not supported currently. Current scope: $currentKey")
+        }
 
         lastKey = currentKey
+        lastCallbacks = current
         currentKey = JoinedKey(lastKey, key)
         current = null
     }
@@ -42,6 +47,10 @@ internal class ScopedCallbacks private constructor(
         }
 
         currentKey = lastKey ?: rootKey
+        current = lastCallbacks
+
+        lastKey = null
+        lastCallbacks = null
     }
 
     fun evaluationStarted() {

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -6,6 +6,7 @@ import com.instacart.formula.test.TestCallback
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.test.test
 import io.reactivex.Observable
+import org.junit.Ignore
 import org.junit.Test
 
 class FormulaRuntimeTest {
@@ -592,5 +593,21 @@ class FormulaRuntimeTest {
                     FromObservableWithInputFormula.Item("2")
                 )
             }
+    }
+
+    @Test
+    fun `mixing callback use with key use`() {
+        MixingCallbackUseWithKeyUse.ParentFormula()
+            .test()
+            .assertRenderModelCount(1)
+    }
+
+    // TODO: maybe worth adding support eventually.
+    @Test
+    fun `nested keys are not allowed`() {
+        NestedKeyFormula()
+            .start()
+            .test()
+            .assertError { it is java.lang.IllegalStateException && it.message.orEmpty().startsWith("Nested scopes are not supported currently.") }
     }
 }

--- a/formula/src/test/java/com/instacart/formula/MixingCallbackUseWithKeyUse.kt
+++ b/formula/src/test/java/com/instacart/formula/MixingCallbackUseWithKeyUse.kt
@@ -1,0 +1,32 @@
+package com.instacart.formula
+
+class MixingCallbackUseWithKeyUse {
+
+    class ParentRenderModel(
+        val firstCallback: () -> Unit,
+        val secondCallback: () -> Unit,
+        val thirdCallback: () -> Unit
+    )
+
+    class ParentFormula : Formula<Unit, Unit, ParentRenderModel> {
+        override fun initialState(input: Unit) = Unit
+
+        override fun evaluate(
+            input: Unit,
+            state: Unit,
+            context: FormulaContext<Unit>
+        ): Evaluation<ParentRenderModel> {
+
+
+            return Evaluation(
+                renderModel = ParentRenderModel(
+                    firstCallback = context.callback { none() },
+                    secondCallback = context.key("scoped") {
+                        context.callback { none() }
+                    },
+                    thirdCallback = context.callback { none() }
+                )
+            )
+        }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/NestedKeyFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/NestedKeyFormula.kt
@@ -1,0 +1,27 @@
+package com.instacart.formula
+
+class NestedKeyFormula : Formula<Unit, Unit, NestedKeyFormula.RenderModel> {
+
+    class RenderModel(val callback: () -> Unit)
+
+    override fun initialState(input: Unit) = Unit
+
+    override fun evaluate(
+        input: Unit,
+        state: Unit,
+        context: FormulaContext<Unit>
+    ): Evaluation<RenderModel> {
+
+        val callback = context.key("first level") {
+            context.key("second level") {
+                context.callback {
+                    none()
+                }
+            }
+        }
+
+        return Evaluation(
+            renderModel = RenderModel(callback)
+        )
+    }
+}


### PR DESCRIPTION
The following scenario was causing a crash.
```kotin
val callback = context.callback {...}
val scoped = context.key("some key") {
  context.callback { ... }
}
// This will cause a crash
val callback2 = context.callback { ... }
```

The problem was within `ScopedCallbacks.enterScope()` & `ScopedCallbacks.exitScope` functions.

