### PR TITLE
Add alternative Formula classes

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,10 +4,10 @@ apply plugin: "com.github.ben-manes.versions"
 buildscript {
     ext {
         minSdk = 21
-        targetSdk = 28
-        compileSdk = 28
+        targetSdk = 29
+        compileSdk = 29
 
-        kotlinVersion = '1.3.50'
+        kotlinVersion = '1.3.61'
 
         versions = [:]
         libraries = [:]
@@ -21,11 +21,11 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.1'
+        classpath 'com.android.tools.build:gradle:3.5.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion"
         classpath "com.github.laimiux:gradle-android-junit-jacoco-plugin:a910712557"
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
-        classpath "com.github.ben-manes:gradle-versions-plugin:0.26.0"
+        classpath "com.github.ben-manes:gradle-versions-plugin:0.27.0"
         classpath "org.jetbrains.dokka:dokka-gradle-plugin:0.9.18"
         classpath "org.jetbrains.dokka:dokka-android-gradle-plugin:0.9.18"
         classpath "com.vanniktech:gradle-maven-publish-plugin:0.8.0"

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
@@ -23,7 +23,7 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
     }
 
     private val contract: FragmentContract<RenderModel> by lazy(LazyThreadSafetyMode.NONE) {
-        arguments!!.getParcelable<FragmentContract<RenderModel>>(ARG_CONTRACT)
+        arguments!!.getParcelable<FragmentContract<RenderModel>>(ARG_CONTRACT)!!
     }
 
     // State relay + disposable

--- a/formula/src/main/java/com/instacart/formula/InputlessFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/InputlessFormula.kt
@@ -1,0 +1,23 @@
+package com.instacart.formula
+
+/**
+ * Version of [Formula] which requires no input
+ */
+abstract class InputlessFormula<State, RenderModel> : Formula<Unit, State, RenderModel> {
+
+    final override fun evaluate(
+        input: Unit,
+        state: State,
+        context: FormulaContext<State>
+    ): Evaluation<RenderModel> {
+        return evaluate(state, context)
+    }
+
+    /**
+     * Same as [evaluate] but just with the needed state and context
+     */
+     abstract fun evaluate(
+        state: State,
+        context: FormulaContext<State>
+    ): Evaluation<RenderModel>
+}

--- a/formula/src/main/java/com/instacart/formula/RenderFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/RenderFormula.kt
@@ -1,0 +1,24 @@
+package com.instacart.formula
+
+/**
+ * Version of [Formula] which requires no state or input
+ */
+abstract class RenderFormula<RenderModel> : Formula<Unit, Unit, RenderModel> {
+
+    final override fun initialState(input: Unit) = Unit
+
+    final override fun evaluate(
+        input: Unit,
+        state: Unit,
+        context: FormulaContext<Unit>
+    ): Evaluation<RenderModel> {
+        return evaluate(context)
+    }
+
+    /**
+     * Same as [evaluate] but just with the needed context
+     */
+    abstract fun evaluate(
+        context: FormulaContext<Unit>
+    ): Evaluation<RenderModel>
+}

--- a/formula/src/main/java/com/instacart/formula/StatelessFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/StatelessFormula.kt
@@ -1,5 +1,8 @@
 package com.instacart.formula
 
+/**
+ * Version of [Formula] which requires no state
+ */
 abstract class StatelessFormula<Input, RenderModel> : Formula<Input, Unit, RenderModel> {
 
     final override fun initialState(input: Input) = Unit
@@ -12,6 +15,9 @@ abstract class StatelessFormula<Input, RenderModel> : Formula<Input, Unit, Rende
         return evaluate(input, context)
     }
 
+    /**
+     * Same as [evaluate] but just with the needed input and context
+     */
      abstract fun evaluate(
         input: Input,
         context: FormulaContext<Unit>

--- a/formula/src/test/java/com/instacart/formula/AlternativeFormulaTest.kt
+++ b/formula/src/test/java/com/instacart/formula/AlternativeFormulaTest.kt
@@ -1,0 +1,51 @@
+package com.instacart.formula
+
+import io.reactivex.Observable
+import org.junit.Test
+
+class AlternativeFormulaTest {
+
+    @Test fun `using Stateless formula`() {
+        TestStatelessFormula()
+            .start(input = Observable.just(1, 2, 3))
+            .test()
+            .assertValues(1, 2, 3)
+    }
+
+    @Test fun `using Inputless formula`() {
+        TestInputlessFormula()
+            .start()
+            .test()
+            .assertValues(1)
+    }
+
+    @Test fun `using Render formula`() {
+        TestRenderFormula()
+            .start()
+            .test()
+            .assertValues(1)
+    }
+
+    class TestStatelessFormula:  StatelessFormula<Int, Int>() {
+        override fun evaluate(input: Int, context: FormulaContext<Unit>): Evaluation<Int> {
+            return Evaluation(renderModel = input)
+        }
+    }
+
+    class TestInputlessFormula: InputlessFormula<Int, Int>() {
+
+        override fun initialState(input: Unit): Int {
+            return 0
+        }
+
+        override fun evaluate(state: Int, context: FormulaContext<Int>): Evaluation<Int> {
+            return Evaluation(renderModel = 1)
+        }
+    }
+
+    class TestRenderFormula:  RenderFormula<Int>() {
+        override fun evaluate(context: FormulaContext<Unit>): Evaluation<Int> {
+            return Evaluation(renderModel = 1)
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/gradlew
+++ b/gradlew
@@ -7,7 +7,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#      http://www.apache.org/licenses/LICENSE-2.0
+#      https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
@@ -125,8 +125,8 @@ if $darwin; then
     GRADLE_OPTS="$GRADLE_OPTS \"-Xdock:name=$APP_NAME\" \"-Xdock:icon=$APP_HOME/media/gradle.icns\""
 fi
 
-# For Cygwin, switch paths to Windows format before running java
-if $cygwin ; then
+# For Cygwin or MSYS, switch paths to Windows format before running java
+if [ "$cygwin" = "true" -o "$msys" = "true" ] ; then
     APP_HOME=`cygpath --path --mixed "$APP_HOME"`
     CLASSPATH=`cygpath --path --mixed "$CLASSPATH"`
     JAVACMD=`cygpath --unix "$JAVACMD"`

--- a/gradlew.bat
+++ b/gradlew.bat
@@ -5,7 +5,7 @@
 @rem you may not use this file except in compliance with the License.
 @rem You may obtain a copy of the License at
 @rem
-@rem      http://www.apache.org/licenses/LICENSE-2.0
+@rem      https://www.apache.org/licenses/LICENSE-2.0
 @rem
 @rem Unless required by applicable law or agreed to in writing, software
 @rem distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This adds the following alternatives to `Formula`, similar to `StatelessFormula`:
- InputlessFormula
- RenderFormula

Wasn't sure about the naming of the last one (could technically be `InputlessStatelessFormula`, but that feels like a mouthful 😛 ) but I think it probably makes sense, since all the formula does at that point is generate a render model. 