### PR TITLE
[bugfix] fix Stream.onTerminate causing illegal state exception.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 - Removed deprecated `state()` extension
 - Updated AndroidX appcompat to 1.1.0
 - Updated AndroidX fragment-ktx extensions to 1.2.1
-- Bugfix: Fix `Stream.onTerminate` causing illegal transition exception.
+- Bugfix: Fix `Stream.onTerminate` causing illegal state exception.
 
 ## [0.5.3] - December 10, 2019
 - Change child formula key from String to Any.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Removed deprecated `state()` extension
 - Updated AndroidX appcompat to 1.1.0
 - Updated AndroidX fragment-ktx extensions to 1.2.1
+- Bugfix: Fix `Stream.onTerminate` causing illegal transition exception.
 
 ## [0.5.3] - December 10, 2019
 - Change child formula key from String to Any.

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
@@ -33,6 +33,8 @@ class TestFormulaManager<Input, State, RenderModel>(
         return Evaluation(renderModel = renderModel)
     }
 
+    override fun terminateDetachedChildren(currentTransition: Long) = false
+
     override fun terminateOldUpdates(currentTransition: Long): Boolean {
         return false
     }
@@ -42,6 +44,8 @@ class TestFormulaManager<Input, State, RenderModel>(
     }
 
     override fun markAsTerminated() = Unit
+
+    override fun performTerminationSideEffects() = Unit
 
     fun lastInput(): Input {
         return inputs.last()

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -19,9 +19,31 @@ interface FormulaManager<Input, State, RenderModel> {
         transitionId: Long
     ): Evaluation<RenderModel>
 
+    /**
+     * Called after [evaluate] to terminate children that were removed.
+     *
+     * @return True if transition happened while performing this.
+     */
+    fun terminateDetachedChildren(currentTransition: Long): Boolean
+
+    /**
+     * Called after [evaluate] to terminate old streams.
+     */
     fun terminateOldUpdates(currentTransition: Long): Boolean
 
+    /**
+     * Called after [evaluate] to start new streams.
+     */
     fun startNewUpdates(currentTransition: Long): Boolean
 
+    /**
+     * Called when [Formula] is removed. This is should not trigger any external side-effects,
+     * only mark itself and its children as terminated.
+     */
     fun markAsTerminated()
+
+    /**
+     * Called when we are ready to perform termination side-effects.
+     */
+    fun performTerminationSideEffects()
 }

--- a/formula/src/test/java/com/instacart/formula/NestedTerminationWithInputChanged.kt
+++ b/formula/src/test/java/com/instacart/formula/NestedTerminationWithInputChanged.kt
@@ -1,0 +1,47 @@
+package com.instacart.formula
+
+import com.instacart.formula.NestedTerminationWithInputChanged.RenderModel
+
+/**
+ * In a single formula pass:
+ * 1. Parent formula provides a new state by `onInputChanged()`
+ * 2. Then parent declares a callback.
+ * 3. A child formula fires a termination event.
+ * 4. Because Frame object wasn't updated to have the new state, a new evaluation is triggered
+ * 5. Parent tries to declare a callback in a bad state.e
+ */
+class NestedTerminationWithInputChanged: Formula<Boolean, Boolean, RenderModel> {
+    object RenderModel
+
+    val terminateFormula = TerminateFormula()
+    private val passThroughFormula = object : StatelessFormula<Boolean, Unit>() {
+        override fun evaluate(input: Boolean, context: FormulaContext<Unit>): Evaluation<Unit> {
+            if (input) {
+                context.child(terminateFormula).input(Unit)
+            }
+            return Evaluation(
+                renderModel = Unit
+            )
+        }
+    }
+
+    override fun initialState(input: Boolean): Boolean = input
+
+    override fun onInputChanged(oldInput: Boolean, input: Boolean, state: Boolean): Boolean {
+        return input
+    }
+
+    override fun evaluate(
+        input: Boolean,
+        state: Boolean,
+        context: FormulaContext<Boolean>
+    ): Evaluation<RenderModel> {
+        // We use a callback to check if formula runtime is in the right state.
+        context.callback { none() }
+        context.child(passThroughFormula).input(state)
+
+        return Evaluation(
+            renderModel = RenderModel
+        )
+    }
+}

--- a/samples/counter/build.gradle
+++ b/samples/counter/build.gradle
@@ -47,4 +47,5 @@ dependencies {
     testImplementation libraries.androidx.test.runner
     testImplementation libraries.androidx.test.espresso.core
     testImplementation libraries.robolectric
+    testImplementation project(":formula-test")
 }

--- a/samples/stopwatch/build.gradle
+++ b/samples/stopwatch/build.gradle
@@ -47,4 +47,5 @@ dependencies {
     testImplementation libraries.androidx.test.runner
     testImplementation libraries.androidx.test.espresso.core
     testImplementation libraries.robolectric
+    testImplementation project(":formula-test")
 }


### PR DESCRIPTION
It was not easy to replicate, but the exception is as follows:
java.lang.IllegalStateException: Callback class com.instacart.formula.fragment.FragmentFlowStore$evaluate$$inlined$eventCallback$1 is already defined. Are you calling it in a loop or reusing a method? You can wrap the call with FormulaContext.key
