### PR TITLE
Avoid exhausting the stack when doing transitions.

### DIFF
--- a/formula/src/test/java/com/instacart/formula/ExtremelyNestedFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/ExtremelyNestedFormula.kt
@@ -1,0 +1,34 @@
+package com.instacart.formula
+
+object ExtremelyNestedFormula {
+    class TestFormula(private val childFormula: Formula<Unit, *, Int>?) : Formula<Unit, Int, Int> {
+        override fun initialState(input: Unit): Int = 0
+
+        override fun evaluate(
+            input: Unit,
+            state: Int,
+            context: FormulaContext<Int>
+        ): Evaluation<Int> {
+            val childValue = if (childFormula != null) {
+                context.child(childFormula).input(Unit)
+            } else {
+                0
+            }
+
+            return Evaluation(
+                renderModel = state + childValue,
+                updates = context.updates {
+                    events(Stream.onInit()) {
+                        transition(state + 1)
+                    }
+                }
+            )
+        }
+    }
+
+    fun nested(levels: Int): TestFormula {
+        return (1 until levels).fold(TestFormula(null)) { child, value ->
+            TestFormula(child)
+        }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -6,6 +6,7 @@ import com.instacart.formula.test.TestCallback
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.test.test
 import io.reactivex.Observable
+import org.junit.Ignore
 import org.junit.Test
 
 class FormulaRuntimeTest {
@@ -615,6 +616,28 @@ class FormulaRuntimeTest {
                     FromObservableWithInputFormula.Item("2")
                 )
             }
+    }
+
+    @Test
+    fun `initialize 100 levels nested formula`() {
+        ExtremelyNestedFormula.nested(100).test().renderModel {
+            assertThat(this).isEqualTo(100)
+        }
+    }
+
+    @Test
+    fun `initialize 250 levels nested formula`() {
+        ExtremelyNestedFormula.nested(250).test().renderModel {
+            assertThat(this).isEqualTo(250)
+        }
+    }
+
+    @Ignore("stack overflows when there are 500 nested child formulas")
+    @Test
+    fun `initialize 500 levels nested formula`() {
+        ExtremelyNestedFormula.nested(500).test().renderModel {
+            assertThat(this).isEqualTo(500)
+        }
     }
 
     @Test


### PR DESCRIPTION
Updating formula runtime to use a while loop to iterate over side-effects instead of recursion based behavior. The stack still overflows at 500 nested child formulas, however for a different reason than what this PR fixes. Without this change, it would overflow at 100 child formulas.