### PR TITLE
Adding visibleState() to FragmentFlowState.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Updated AndroidX appcompat to 1.1.0
 - Updated AndroidX fragment-ktx extensions to 1.2.1
 - Bugfix: Fix `Stream.onTerminate` causing illegal state exception.
+- **Breaking**: In formula-android, replacing lastEntry() with visibleState() in FragmentFlowState.
 
 ## [0.5.3] - December 10, 2019
 - Change child formula key from String to Any.

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowState.kt
@@ -1,8 +1,18 @@
 package com.instacart.formula.fragment
 
-import com.instacart.formula.integration.FlowState
+import com.instacart.formula.integration.KeyState
 
 /**
- * Represents a [FlowState] where the key type is [FragmentContract]
+ * Represents currently [activeKeys] and their [states].
+ *
+ * @param activeKeys Fragment contracts that are running their state management.
+ * @param visibleKeys Fragment contracts that are currently visible to the user.
+ * @param states Last emitted state of each active [FragmentContract].
  */
-typealias FragmentFlowState = FlowState<FragmentContract<*>>
+data class FragmentFlowState(
+    val activeKeys: List<FragmentContract<*>> = emptyList(),
+    val visibleKeys: List<FragmentContract<*>> = emptyList(),
+    val states: Map<FragmentContract<*>, KeyState<FragmentContract<*>>> = emptyMap()
+) {
+    fun visibleState() = visibleKeys.lastOrNull()?.let { states[it] }
+}

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
@@ -1,65 +1,34 @@
 package com.instacart.formula.fragment
 
-import android.content.Context
 import androidx.fragment.app.Fragment
-import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentInspector
 import androidx.fragment.app.FragmentManager
-import com.instacart.formula.fragment.FragmentLifecycle.lifecycleEvents
 import com.instacart.formula.integration.LifecycleEvent
-import io.reactivex.Observable
-import io.reactivex.android.MainThreadDisposable
 
 /**
  * Provides utility method [lifecycleEvents] to track what fragments are added and removed from the backstack.
  */
-object FragmentLifecycle {
+internal object FragmentLifecycle {
 
-    fun shouldTrack(fragment: Fragment): Boolean {
+    internal fun shouldTrack(fragment: Fragment): Boolean {
         return !fragment.retainInstance && !FragmentInspector.isHeadless(fragment)
     }
 
-    private fun isKept(fragmentManager: FragmentManager, fragment: Fragment): Boolean {
+    internal fun isKept(fragmentManager: FragmentManager, fragment: Fragment): Boolean {
         return !fragment.isRemoving
     }
 
-    /**
-     * Must subscribe to the state before calling Activity.super.onCreate(),
-     * otherwise you might miss fragment event
-     */
-    fun lifecycleEvents(activity: FragmentActivity): Observable<FragmentLifecycleEvent> {
-        return Observable.create { emitter ->
-            val listener = object : FragmentManager.FragmentLifecycleCallbacks() {
-                override fun onFragmentAttached(fm: FragmentManager, f: Fragment, context: Context) {
-                    if (shouldTrack(f)) {
-                        val fragment = f as? BaseFormulaFragment<*>
-                        val contract = fragment?.getFragmentContract() ?: EmptyFragmentContract(f.tag.orEmpty())
-                        emitter.onNext(LifecycleEvent.Added(contract))
-                    }
-                }
-
-                override fun onFragmentDetached(fm: FragmentManager, f: Fragment) {
-                    super.onFragmentDetached(fm, f)
-                    // Only trigger detach, when fragment is actually being removed from the backstack
-                    if (shouldTrack(f) && !isKept(fm, f)) {
-                        emitter.onNext(createRemovedEvent(f))
-                    }
-                }
-            }
-
-            activity.supportFragmentManager.registerFragmentLifecycleCallbacks(listener, false)
-
-            emitter.setDisposable(object : MainThreadDisposable() {
-                override fun onDispose() {
-                    activity.supportFragmentManager.unregisterFragmentLifecycleCallbacks(listener)
-                }
-            })
-        }
+    internal fun createAddedEvent(f: Fragment): LifecycleEvent.Added<FragmentContract<Nothing>> {
+        return LifecycleEvent.Added(f.contract())
     }
 
     internal fun createRemovedEvent(f: Fragment): LifecycleEvent.Removed<FragmentContract<Nothing>> {
         val fragment = f as? BaseFormulaFragment<*>
-        val contract = fragment?.getFragmentContract() ?: EmptyFragmentContract(f.tag.orEmpty())
-        return LifecycleEvent.Removed(contract, fragment?.currentState())
+        return LifecycleEvent.Removed(f.contract(), fragment?.currentState())
+    }
+
+    internal fun Fragment.contract(): FragmentContract<*> {
+        val fragment = this as? BaseFormulaFragment<*>
+        return fragment?.getFragmentContract() ?: EmptyFragmentContract(tag.orEmpty())
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula.integration
 
+import android.content.Context
 import android.os.Bundle
 import android.view.View
 import androidx.fragment.app.Fragment
@@ -13,7 +14,8 @@ import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentFlowState
 import com.instacart.formula.fragment.FragmentLifecycle
 import com.instacart.formula.fragment.FragmentLifecycleEvent
-import io.reactivex.disposables.CompositeDisposable
+import com.instacart.formula.integration.internal.forEachIndices
+import java.util.LinkedList
 
 /**
  * Renders [FragmentFlowState] and provides back button handling.
@@ -23,112 +25,122 @@ import io.reactivex.disposables.CompositeDisposable
  * [activity] activity within which the [FragmentFlowRenderView] lives.
  * [onLifecycleEvent] fragment lifecycle events that should be passed to the [com.instacart.formula.fragment.FragmentFlowStore]
  */
-class FragmentFlowRenderView(
+internal class FragmentFlowRenderView(
     private val activity: FragmentActivity,
     private val onLifecycleEvent: (FragmentLifecycleEvent) -> Unit,
     private val onLifecycleState: ((FragmentContract<*>, Lifecycle.State) -> Unit)? = null
 ) : RenderView<FragmentFlowState> {
 
     private var fragmentState: FragmentFlowState? = null
-    private var currentFragmentRenderModel: Any? = null
-
-    private val disposables = CompositeDisposable()
-
-    private val visibleFragments: MutableMap<String, Fragment> = mutableMapOf()
+    private val visibleFragments: LinkedList<Fragment> = LinkedList()
 
     private var backstackEntries: Int = 0
     private var backstackPopped: Boolean = false
     private var removedEarly = mutableListOf<FragmentContract<*>>()
+
+    private val callback = object : FragmentManager.FragmentLifecycleCallbacks() {
+        override fun onFragmentViewCreated(
+            fm: FragmentManager,
+            f: Fragment,
+            v: View,
+            savedInstanceState: Bundle?
+        ) {
+            super.onFragmentViewCreated(fm, f, v, savedInstanceState)
+
+            backstackEntries = activity.supportFragmentManager.backStackEntryCount
+            visibleFragments.add(f)
+
+            fragmentState?.let {
+                updateVisibleFragments(it)
+            }
+
+            notifyLifecycleStateChanged(f, Lifecycle.State.CREATED)
+        }
+
+        override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
+            super.onFragmentStarted(fm, f)
+            notifyLifecycleStateChanged(f, Lifecycle.State.STARTED)
+        }
+
+        override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
+            super.onFragmentResumed(fm, f)
+            notifyLifecycleStateChanged(f, Lifecycle.State.RESUMED)
+        }
+
+        override fun onFragmentPaused(fm: FragmentManager, f: Fragment) {
+            super.onFragmentPaused(fm, f)
+            notifyLifecycleStateChanged(f, Lifecycle.State.STARTED)
+        }
+
+        override fun onFragmentStopped(fm: FragmentManager, f: Fragment) {
+            super.onFragmentStopped(fm, f)
+            notifyLifecycleStateChanged(f, Lifecycle.State.CREATED)
+        }
+
+        override fun onFragmentViewDestroyed(fm: FragmentManager, f: Fragment) {
+            super.onFragmentViewDestroyed(fm, f)
+            visibleFragments.remove(f)
+
+            notifyLifecycleStateChanged(f, Lifecycle.State.DESTROYED)
+            // This means that fragment is removed due to backstack change.
+            if (backstackPopped) {
+                // Reset
+                backstackPopped = false
+
+                val event = FragmentLifecycle.createRemovedEvent(f)
+                removedEarly.add(event.key)
+                onLifecycleEvent(event)
+            }
+        }
+
+        override fun onFragmentAttached(fm: FragmentManager, f: Fragment, context: Context) {
+            super.onFragmentAttached(fm, f, context)
+            if (FragmentLifecycle.shouldTrack(f)) {
+                onLifecycleEvent(FragmentLifecycle.createAddedEvent(f))
+            }
+        }
+
+        override fun onFragmentDetached(fm: FragmentManager, f: Fragment) {
+            super.onFragmentDetached(fm, f)
+            // Only trigger detach, when fragment is actually being removed from the backstack
+            if (FragmentLifecycle.shouldTrack(f) && !FragmentLifecycle.isKept(fm, f)) {
+                val event = FragmentLifecycle.createRemovedEvent(f)
+                val wasRemovedEarly = removedEarly.remove(event.key)
+                if (!wasRemovedEarly) {
+                    onLifecycleEvent(event)
+                }
+            }
+        }
+    }
 
     init {
         activity.supportFragmentManager.addOnBackStackChangedListener {
             recordBackstackChange()
         }
 
-        activity.supportFragmentManager.registerFragmentLifecycleCallbacks(object :
-            FragmentManager.FragmentLifecycleCallbacks() {
-
-            override fun onFragmentViewCreated(fm: FragmentManager, f: Fragment, v: View, savedInstanceState: Bundle?) {
-                super.onFragmentViewCreated(fm, f, v, savedInstanceState)
-
-                backstackEntries = activity.supportFragmentManager.backStackEntryCount
-
-                val tag = f.tag
-                if (tag != null) {
-                    visibleFragments[tag] = f
-                }
-
-                fragmentState?.let {
-                    updateVisibleFragments(it)
-                }
-
-                notifyLifecycleStateChanged(f, Lifecycle.State.CREATED)
-            }
-
-            override fun onFragmentStarted(fm: FragmentManager, f: Fragment) {
-                super.onFragmentStarted(fm, f)
-                notifyLifecycleStateChanged(f, Lifecycle.State.STARTED)
-            }
-
-            override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
-                super.onFragmentResumed(fm, f)
-                notifyLifecycleStateChanged(f, Lifecycle.State.RESUMED)
-            }
-
-            override fun onFragmentPaused(fm: FragmentManager, f: Fragment) {
-                super.onFragmentPaused(fm, f)
-                notifyLifecycleStateChanged(f, Lifecycle.State.STARTED)
-            }
-
-            override fun onFragmentStopped(fm: FragmentManager, f: Fragment) {
-                super.onFragmentStopped(fm, f)
-                notifyLifecycleStateChanged(f, Lifecycle.State.CREATED)
-            }
-
-            override fun onFragmentViewDestroyed(fm: FragmentManager, f: Fragment) {
-                super.onFragmentViewDestroyed(fm, f)
-                visibleFragments.remove(f.tag)
-
-                notifyLifecycleStateChanged(f, Lifecycle.State.DESTROYED)
-                // This means that fragment is removed due to backstack change.
-                if (backstackPopped) {
-                    // Reset
-                    backstackPopped = false
-
-                    val event = FragmentLifecycle.createRemovedEvent(f)
-                    removedEarly.add(event.key)
-                    onLifecycleEvent(event)
-                }
-            }
-        }, false)
-
-        disposables.add(FragmentLifecycle.lifecycleEvents(activity).subscribe {
-            val shouldFireEvent = it !is LifecycleEvent.Removed || !removedEarly.remove(it.key)
-            if (shouldFireEvent) {
-                onLifecycleEvent(it)
-            }
-        })
+        activity.supportFragmentManager.registerFragmentLifecycleCallbacks(callback, false)
     }
 
     override val renderer: Renderer<FragmentFlowState> = Renderer.create {
         updateVisibleFragments(it)
 
         fragmentState = it
-        currentFragmentRenderModel = it.lastEntry()?.renderModel
     }
 
     fun onBackPressed(): Boolean {
-        // TODO: only visible fragments should handle back presses.
-        // currentFragmentRenderModel might not be currently visible fragment.
-        val state = currentFragmentRenderModel
-        return state is BackCallback && state.onBackPressed()
+        val lastFragment = visibleFragments.last()
+        if (lastFragment is BaseFormulaFragment<*>) {
+            val state = fragmentState?.states?.get(lastFragment.getFragmentContract())?.renderModel
+            return state is BackCallback && state.onBackPressed()
+        }
+        return false
     }
 
     /**
      * This method must be invoked in [android.app.Activity.onDestroy]
      */
     fun dispose() {
-        disposables.dispose()
+        activity.supportFragmentManager.unregisterFragmentLifecycleCallbacks(callback)
     }
 
     private fun notifyLifecycleStateChanged(fragment: Fragment, newState: Lifecycle.State) {
@@ -140,10 +152,11 @@ class FragmentFlowRenderView(
     }
 
     private fun updateVisibleFragments(state: FragmentFlowState) {
-        state.states.forEach { entry ->
-            val fragment = visibleFragments[entry.key.tag]
-            if (fragment != null && fragment is BaseFormulaFragment<*>) {
-                (fragment as BaseFormulaFragment<Any>).setState(entry.value.renderModel)
+        visibleFragments.forEachIndices { fragment ->
+            if (fragment is BaseFormulaFragment<*>) {
+                state.states[fragment.getFragmentContract()]?.let {
+                    (fragment as BaseFormulaFragment<Any>).setState(it.renderModel)
+                }
             }
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/integration/StoreManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/StoreManager.kt
@@ -38,9 +38,8 @@ internal class StoreManager(
         val renderView = FragmentFlowRenderView(
             activity = activity,
             onLifecycleEvent = store::onLifecycleEvent,
-            onLifecycleState = { contract, state ->
-                store.context.holder.updateFragmentLifecycleState(contract, state)
-            })
+            onLifecycleState = store::onLifecycleState
+        )
 
         renderViewMap[activity] = renderView
     }

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/Utils.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/Utils.kt
@@ -1,0 +1,8 @@
+package com.instacart.formula.integration.internal
+
+/** Functionally the same as [Iterable.forEach] except it generates an index-based loop that doesn't use an [Iterator]. */
+internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
+    for (i in indices) {
+        action(get(i))
+    }
+}

--- a/formula-android/src/test/java/com/instacart/formula/fragment/FragmentFlowStoreTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/fragment/FragmentFlowStoreTest.kt
@@ -115,7 +115,7 @@ class FragmentFlowStoreTest {
         }
 
         return FragmentFlowState(
-            backStack = BackStack(states.map { it.first }),
+            activeKeys = states.map { it.first },
             states = keyStates
         )
     }


### PR DESCRIPTION
`FlowState.lastEntry()` is not a reliable way to get the current screen, it makes an assumption that the back stack is populated in order. In some scenarios such as activity restoration, it might not be the case. To make this a bit more robust, we are tracking which fragment views are created and assume that the last created view is the current page.