### PR TITLE
Bugfix: FragmentFlowState.isVisibleState() was showing incorrect state.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
@@ -19,16 +19,16 @@ internal object FragmentLifecycle {
     }
 
     internal fun createAddedEvent(f: Fragment): LifecycleEvent.Added<FragmentContract<Nothing>> {
-        return LifecycleEvent.Added(f.contract())
+        return LifecycleEvent.Added(f.getFragmentContract())
     }
 
     internal fun createRemovedEvent(f: Fragment): LifecycleEvent.Removed<FragmentContract<Nothing>> {
         val fragment = f as? BaseFormulaFragment<*>
-        return LifecycleEvent.Removed(f.contract(), fragment?.currentState())
+        return LifecycleEvent.Removed(f.getFragmentContract(), fragment?.currentState())
     }
+}
 
-    internal fun Fragment.contract(): FragmentContract<*> {
-        val fragment = this as? BaseFormulaFragment<*>
-        return fragment?.getFragmentContract() ?: EmptyFragmentContract(tag.orEmpty())
-    }
+internal fun Fragment.getFragmentContract(): FragmentContract<*> {
+    val fragment = this as? BaseFormulaFragment<*>
+    return fragment?.getFragmentContract() ?: EmptyFragmentContract(tag.orEmpty())
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
@@ -63,4 +63,8 @@ class ActivityStore<Activity : FragmentActivity>(
         }
         context.holder.updateFragmentLifecycleState(contract, state)
     }
+
+    fun onFragmentViewStateChanged(contract: FragmentContract<*>, isVisible: Boolean) {
+        fragmentFlowStore.onVisibilityChanged(contract, isVisible)
+    }
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -29,7 +29,8 @@ import java.util.LinkedList
 internal class FragmentFlowRenderView(
     private val activity: FragmentActivity,
     private val onLifecycleEvent: (FragmentLifecycleEvent) -> Unit,
-    private val onLifecycleState: ((FragmentContract<*>, Lifecycle.State) -> Unit)? = null
+    private val onLifecycleState: (FragmentContract<*>, Lifecycle.State) -> Unit,
+    private val onFragmentViewStateChanged: (FragmentContract<*>, isVisible: Boolean) -> Unit
 ) : RenderView<FragmentFlowState> {
 
     private var fragmentState: FragmentFlowState? = null
@@ -55,6 +56,7 @@ internal class FragmentFlowRenderView(
                 updateVisibleFragments(it)
             }
 
+            onFragmentViewStateChanged(f.getFragmentContract(), true)
             notifyLifecycleStateChanged(f, Lifecycle.State.CREATED)
         }
 
@@ -82,6 +84,7 @@ internal class FragmentFlowRenderView(
             super.onFragmentViewDestroyed(fm, f)
             visibleFragments.remove(f)
 
+            onFragmentViewStateChanged(f.getFragmentContract(), false)
             notifyLifecycleStateChanged(f, Lifecycle.State.DESTROYED)
             // This means that fragment is removed due to backstack change.
             if (backstackPopped) {
@@ -145,7 +148,7 @@ internal class FragmentFlowRenderView(
     }
 
     private fun notifyLifecycleStateChanged(fragment: Fragment, newState: Lifecycle.State) {
-        onLifecycleState?.invoke(fragment.getFragmentContract(), newState)
+        onLifecycleState.invoke(fragment.getFragmentContract(), newState)
     }
 
     private fun updateVisibleFragments(state: FragmentFlowState) {

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -14,6 +14,7 @@ import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentFlowState
 import com.instacart.formula.fragment.FragmentLifecycle
 import com.instacart.formula.fragment.FragmentLifecycleEvent
+import com.instacart.formula.fragment.getFragmentContract
 import com.instacart.formula.integration.internal.forEachIndices
 import java.util.LinkedList
 
@@ -144,11 +145,7 @@ internal class FragmentFlowRenderView(
     }
 
     private fun notifyLifecycleStateChanged(fragment: Fragment, newState: Lifecycle.State) {
-        if (fragment is BaseFormulaFragment<*>) {
-            onLifecycleState?.let {
-                it.invoke(fragment.getFragmentContract(), newState)
-            }
-        }
+        onLifecycleState?.invoke(fragment.getFragmentContract(), newState)
     }
 
     private fun updateVisibleFragments(state: FragmentFlowState) {

--- a/formula-android/src/main/java/com/instacart/formula/integration/StoreManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/StoreManager.kt
@@ -38,7 +38,8 @@ internal class StoreManager(
         val renderView = FragmentFlowRenderView(
             activity = activity,
             onLifecycleEvent = store::onLifecycleEvent,
-            onLifecycleState = store::onLifecycleState
+            onLifecycleState = store::onLifecycleState,
+            onFragmentViewStateChanged = store::onFragmentViewStateChanged
         )
 
         renderViewMap[activity] = renderView


### PR DESCRIPTION
There are a couple issues with `FragmentFlowState.isVisibleState()` that this PR fixes:
- It didn't take into account non-formula fragments that are visible.
- It would trigger `isVisible = true` when fragment is stopped.
