### PR TITLE
Fixing duplicate visibility events.

### DIFF
--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -206,8 +206,13 @@ class FragmentFlowRenderViewTest {
     }
 
     private fun assertVisibleContract(contract: FragmentContract<*>) {
+        assertNoDuplicates(contract)
         // TODO: would be best to test visibleState() however `FragmentFlowState.states` is empty
         assertThat(scenario.get { lastState?.visibleKeys?.lastOrNull() }).isEqualTo(contract)
+    }
+
+    private fun assertNoDuplicates(contract: FragmentContract<*>) {
+        assertThat(lastState?.visibleKeys?.count { it == contract }).isEqualTo(1)
     }
 
     private fun <T : Any> sendStateUpdate(contract: FragmentContract<T>, update: T) {

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
@@ -56,7 +56,12 @@ class FragmentFlowStore(
     fun state(): Observable<FragmentFlowState> {
         val contractShown = visibleContractEvents.map { contract ->
             { list: List<FragmentContract<*>> ->
-                list + contract
+                if (!list.contains(contract)) {
+                    list + contract
+                } else {
+                    // TODO: should we log this duplicate visibility event?
+                    list
+                }
             }
         }
 

--- a/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
@@ -53,14 +53,6 @@ class ActivityStore<Activity : FragmentActivity>(
     }
 
     fun onLifecycleState(contract: FragmentContract<*>, state: Lifecycle.State) {
-        val fragmentContractShownEvent = when {
-            state == Lifecycle.State.CREATED -> true
-            state == Lifecycle.State.DESTROYED -> false
-            else -> null
-        }
-        fragmentContractShownEvent?.let { visible ->
-            fragmentFlowStore.onVisibilityChanged(contract, visible)
-        }
         context.holder.updateFragmentLifecycleState(contract, state)
     }
 


### PR DESCRIPTION
## What
The issue was that we were firing visibility events in `onLifecycleState` and `onFragmentViewStateChanged`.