### PR TITLE
Ensure renderer state is not broken by an error.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
@@ -45,7 +45,10 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
             .doOnNext {
                 // Timber.d("render / ${this@FormulaFragment}")
             }
-            .subscribe(component.renderView.renderer::render)
+            .subscribe {
+                // TODO: add try / catch error handling in the future.
+                component.renderView.renderer.render(it)
+            }
 
         this.lifecycleCallback = component.lifecycleCallbacks
         lifecycleCallback?.onViewCreated(view, savedInstanceState)

--- a/formula/src/main/java/com/instacart/formula/Renderer.kt
+++ b/formula/src/main/java/com/instacart/formula/Renderer.kt
@@ -49,11 +49,18 @@ class Renderer<in RenderModel> private constructor(
         val local = last
         last = renderModel
 
-        if (lastState == State.NOT_INITIALIZED || local != renderModel) {
-            renderFunction(renderModel)
+        try {
+            if (lastState == State.NOT_INITIALIZED || local != renderModel) {
+                renderFunction(renderModel)
+            }
+            state = State.INITIALIZED
+        } catch (e: Throwable) {
+            // Reset state
+            last = local
+            state = lastState
+            // Rethrow the exception
+            throw e
         }
-
-        state = State.INITIALIZED
 
         // Check if there is a pending update and execute it.
         val localPending = pending

--- a/formula/src/test/java/com/instacart/formula/RendererTest.kt
+++ b/formula/src/test/java/com/instacart/formula/RendererTest.kt
@@ -64,6 +64,26 @@ class RendererTest {
         subject.assertRenderedValues(null)
     }
 
+    @Test fun `handling exceptions in rendering`() {
+        var crash: Boolean = true
+        val subject = TestSubject<String?> { renderer, value ->
+            if (crash) {
+                crash = false
+                throw IllegalStateException("you can't do this")
+            }
+        }
+
+        try {
+            subject.render(null)
+        } catch (e: Throwable) {
+            // Should log exceptions
+        } finally {
+            subject.render(null)
+        }
+
+        subject.assertRenderedValues(null, null)
+    }
+
     class TestSubject<T>(private val postRender: (Renderer<T>, T) -> Unit = { _, _ -> Unit }) {
         private val results = mutableListOf<T>()
         lateinit var reference: Renderer<T>


### PR DESCRIPTION
In case of an error, let's reset the internal renderer state so it would be able to accept new render models.