### PR TITLE
Global fragment rendering error handling.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -46,6 +46,7 @@ internal class ActivityManager<Activity : FragmentActivity>(
         // Initialize render view
         fragmentRenderView = FragmentFlowRenderView(
             activity = activity,
+            fragmentEnvironment = environment,
             onLifecycleEvent = {
                 store.contracts.onLifecycleEffect(it)
                 store.onFragmentLifecycleEvent?.invoke(it)

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
@@ -13,7 +13,8 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
     companion object {
         private const val ARG_CONTRACT = "formula fragment contract"
 
-        @JvmStatic fun <State> newInstance(contract: FragmentContract<State>): FormulaFragment<State> {
+        @JvmStatic
+        fun <State> newInstance(contract: FragmentContract<State>): FormulaFragment<State> {
             return FormulaFragment<State>().apply {
                 arguments = Bundle().apply {
                     putParcelable(ARG_CONTRACT, contract)
@@ -27,6 +28,7 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
     }
 
     // State relay + disposable
+    private lateinit var fragmentEnvironment: FragmentEnvironment
     private val stateRelay: BehaviorRelay<RenderModel> = BehaviorRelay.create()
     private var disposable: Disposable? = null
 
@@ -46,8 +48,11 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
                 // Timber.d("render / ${this@FormulaFragment}")
             }
             .subscribe {
-                // TODO: add try / catch error handling in the future.
-                component.renderView.renderer.render(it)
+                try {
+                    component.renderView.renderer.render(it)
+                } catch (exception: Exception) {
+                    fragmentEnvironment.onScreenError(contract, exception)
+                }
             }
 
         this.lifecycleCallback = component.lifecycleCallbacks
@@ -113,6 +118,10 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
     }
 
     fun renderView(): RenderView<RenderModel>? = renderView
+
+    fun setEnvironment(environment: FragmentEnvironment) {
+        this.fragmentEnvironment = environment
+    }
 
     override fun toString(): String {
         return "${contract.tag} -> $contract"

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -10,7 +10,9 @@ import androidx.lifecycle.Lifecycle
 import com.instacart.formula.RenderView
 import com.instacart.formula.Renderer
 import com.instacart.formula.fragment.BaseFormulaFragment
+import com.instacart.formula.fragment.FormulaFragment
 import com.instacart.formula.fragment.FragmentContract
+import com.instacart.formula.fragment.FragmentEnvironment
 import com.instacart.formula.fragment.FragmentFlowState
 import com.instacart.formula.fragment.FragmentLifecycle
 import com.instacart.formula.fragment.FragmentLifecycleEvent
@@ -28,6 +30,7 @@ import java.util.LinkedList
  */
 internal class FragmentFlowRenderView(
     private val activity: FragmentActivity,
+    private val fragmentEnvironment: FragmentEnvironment,
     private val onLifecycleEvent: (FragmentLifecycleEvent) -> Unit,
     private val onLifecycleState: (FragmentContract<*>, Lifecycle.State) -> Unit,
     private val onFragmentViewStateChanged: (FragmentContract<*>, isVisible: Boolean) -> Unit
@@ -51,6 +54,10 @@ internal class FragmentFlowRenderView(
 
             backstackEntries = activity.supportFragmentManager.backStackEntryCount
             visibleFragments.add(f)
+
+            if (f is FormulaFragment<*>) {
+                f.setEnvironment(fragmentEnvironment)
+            }
 
             fragmentState?.let {
                 updateVisibleFragments(it)

--- a/formula-test/src/test/java/com/instacart/formula/test/TestStreamTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestStreamTest.kt
@@ -25,7 +25,7 @@ class TestStreamTest {
     inline fun fails(action: () -> Unit): Throwable {
         try {
             action()
-        } catch (t: Throwable) {
+        } catch (t: Exception) {
             return t
         }
 

--- a/formula/src/main/java/com/instacart/formula/Renderer.kt
+++ b/formula/src/main/java/com/instacart/formula/Renderer.kt
@@ -54,7 +54,7 @@ class Renderer<in RenderModel> private constructor(
                 renderFunction(renderModel)
             }
             state = State.INITIALIZED
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             // Reset state
             last = local
             state = lastState

--- a/formula/src/test/java/com/instacart/formula/RendererTest.kt
+++ b/formula/src/test/java/com/instacart/formula/RendererTest.kt
@@ -75,7 +75,7 @@ class RendererTest {
 
         try {
             subject.render(null)
-        } catch (e: Throwable) {
+        } catch (e: Exception) {
             // Should log exceptions
         } finally {
             subject.render(null)


### PR DESCRIPTION
Instead of crashing when fragment rendering error occurs, we pass that error to global handler.