### PR TITLE
Replacing store context inline methods with abstract methods.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/StreamConfigurator.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/StreamConfigurator.kt
@@ -1,0 +1,23 @@
+package com.instacart.formula.android
+
+import androidx.fragment.app.FragmentActivity
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+
+/**
+ * Provides ability to configure RxJava streams that will survive configuration changes.
+ */
+interface StreamConfigurator<out Activity : FragmentActivity> {
+
+    /**
+     * Keeps activity in-sync with state observable updates. On activity configuration
+     * changes, the last update is applied to new activity instance.
+     *
+     * @param state a state observable
+     * @param update an update function
+     */
+    fun <State> update(
+        state: Observable<State>,
+        update: (Activity, State) -> Unit
+    ): Disposable
+}

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -32,7 +32,7 @@ internal class ActivityManager<Activity : FragmentActivity>(
         stateSubscription = if (store.streams != null) {
             val disposables = CompositeDisposable()
             disposables.add(fragmentState.connect())
-            disposables.add(store.streams.invoke())
+            disposables.add(store.streams.invoke(StreamConfiguratorIml(delegate)))
             disposables
         } else {
             fragmentState.connect()

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/StreamConfiguratorIml.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/StreamConfiguratorIml.kt
@@ -1,0 +1,31 @@
+package com.instacart.formula.android.internal
+
+import androidx.fragment.app.FragmentActivity
+import com.instacart.formula.android.StreamConfigurator
+import io.reactivex.Observable
+import io.reactivex.disposables.Disposable
+import io.reactivex.functions.BiFunction
+
+internal class StreamConfiguratorIml<out Activity : FragmentActivity>(
+    private val context: ActivityStoreContextImpl<Activity>
+) : StreamConfigurator<Activity> {
+
+    override fun <State> update(
+        state: Observable<State>,
+        update: (Activity, State) -> Unit
+    ): Disposable {
+        // To keep activity & state in sync, we re-emit state on every activity change.
+        val stateEmissions = Observable.combineLatest(
+            state,
+            context.activityStartedEvents(),
+            BiFunction<State, Unit, State> { state, event ->
+                state
+            }
+        )
+        return stateEmissions.subscribe { state ->
+            context.startedActivity()?.let {
+                update(it, state)
+            }
+        }
+    }
+}

--- a/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/ActivityStore.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula.integration
 
 import androidx.fragment.app.FragmentActivity
+import com.instacart.formula.android.StreamConfigurator
 import com.instacart.formula.fragment.FragmentFlowState
 import com.instacart.formula.fragment.FragmentFlowStore
 import com.instacart.formula.fragment.FragmentLifecycleEvent
@@ -13,7 +14,7 @@ import io.reactivex.disposables.Disposable
  *
  * @param contracts Fragment state management defined for this [Activity].
  * @param streams This provides ability to configure arbitrary RxJava streams that survive
- *                configuration changes. Check [ActivityStoreContext.StreamConfigurator] for utility methods.
+ *                configuration changes. Check [com.instacart.formula.android.StreamConfigurator] for utility methods.
  * @param configureActivity This is invoked as part of [com.instacart.formula.FormulaAndroid.onPreCreate]. You can
  *                          use this callback to inject the activity.
  * @param onRenderFragmentState This is invoked after [FragmentFlowState] has been updated.
@@ -21,7 +22,7 @@ import io.reactivex.disposables.Disposable
  */
 class ActivityStore<Activity : FragmentActivity>(
     val contracts: FragmentFlowStore,
-    val streams: (() -> Disposable)? = null,
+    val streams: (StreamConfigurator<Activity>.() -> Disposable)? = null,
     val configureActivity: ((Activity) -> Unit)? = null,
     val onRenderFragmentState: ((Activity, FragmentFlowState) -> Unit)? = null,
     val onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null


### PR DESCRIPTION
### Summary
Replacing inline methods with abstract methods allows us to create a TestActivityStoreContext.