### PR TITLE
Formula manager clean up.

### DIFF
--- a/formula-test/src/main/java/com/instacart/formula/test/ChildFormulaRegistryBuilder.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/ChildFormulaRegistryBuilder.kt
@@ -4,7 +4,7 @@ import com.instacart.formula.Formula
 import kotlin.reflect.KClass
 
 class ChildFormulaRegistryBuilder {
-    internal val testManagers: MutableMap<KClass<*>, TestFormulaManager<*, *, *>> = mutableMapOf()
+    internal val testManagers: MutableMap<KClass<*>, TestFormulaManager<*, *>> = mutableMapOf()
 
     /**
      * Registers a child [RenderModel] that will always be returned.
@@ -13,7 +13,7 @@ class ChildFormulaRegistryBuilder {
         formula: KClass<out Formula<Input, State, RenderModel>>,
         renderModel: RenderModel
     ) {
-        testManagers[formula] = TestFormulaManager<Input, State, RenderModel>(renderModel)
+        testManagers[formula] = TestFormulaManager<Input, RenderModel>(renderModel)
     }
 
     /**

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
@@ -2,14 +2,13 @@ package com.instacart.formula.test
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
-import com.instacart.formula.Effects
 import com.instacart.formula.internal.FormulaManager
 
 /**
  * Used within tests to inspect the values parent [Formula] passes to the child [Formula] and
  * to emit child messages to the parent [Formula].
  */
-class TestFormulaManager<Input, State, RenderModel>(
+class TestFormulaManager<Input, RenderModel>(
     private val renderModel: RenderModel
 ) : FormulaManager<Input, RenderModel> {
 

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
@@ -13,12 +13,7 @@ class TestFormulaManager<Input, State, RenderModel>(
     private val renderModel: RenderModel
 ) : FormulaManager<Input, RenderModel> {
 
-    private var transitionListener: ((Effects?, Boolean) -> Unit) = { _, _ -> Unit }
     private val inputs = mutableListOf<Input>()
-
-    override fun setTransitionListener(listener: (Effects?, isValid: Boolean) -> Unit) {
-        transitionListener = listener
-    }
 
     override fun updateTransitionNumber(number: Long) {
         // no-op

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaManager.kt
@@ -11,7 +11,7 @@ import com.instacart.formula.internal.FormulaManager
  */
 class TestFormulaManager<Input, State, RenderModel>(
     private val renderModel: RenderModel
-) : FormulaManager<Input, State, RenderModel> {
+) : FormulaManager<Input, RenderModel> {
 
     private var transitionListener: ((Effects?, Boolean) -> Unit) = { _, _ -> Unit }
     private val inputs = mutableListOf<Input>()
@@ -25,7 +25,6 @@ class TestFormulaManager<Input, State, RenderModel>(
     }
 
     override fun evaluate(
-        formula: Formula<Input, State, RenderModel>,
         input: Input,
         transitionId: Long
     ): Evaluation<RenderModel> {

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -5,6 +5,7 @@ import com.instacart.formula.FormulaRuntime
 import com.instacart.formula.internal.FormulaManager
 import com.instacart.formula.internal.FormulaManagerFactory
 import com.instacart.formula.internal.FormulaManagerFactoryImpl
+import com.instacart.formula.internal.TransitionListener
 import com.instacart.formula.internal.TransitionLock
 import io.reactivex.Observable
 import kotlin.reflect.KClass
@@ -20,10 +21,11 @@ class TestFormulaObserver<Input : Any, RenderModel : Any, FormulaT : Formula<Inp
         override fun <Input, State, RenderModel> createChildManager(
             formula: Formula<Input, State, RenderModel>,
             input: Input,
-            transitionLock: TransitionLock
+            transitionLock: TransitionLock,
+            transitionListener: TransitionListener
         ): FormulaManager<Input, RenderModel> {
             if (!observer.testManagers.containsKey(formula::class) && observer.defaultToRealFormula) {
-                return FormulaManagerFactoryImpl().createChildManager(formula, input, transitionLock)
+                return FormulaManagerFactoryImpl().createChildManager(formula, input, transitionLock, transitionListener)
             }
 
             return observer.findManager(formula::class)

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -21,7 +21,7 @@ class TestFormulaObserver<Input : Any, RenderModel : Any, FormulaT : Formula<Inp
             formula: Formula<Input, State, RenderModel>,
             input: Input,
             transitionLock: TransitionLock
-        ): FormulaManager<Input, State, RenderModel> {
+        ): FormulaManager<Input, RenderModel> {
             if (!observer.testManagers.containsKey(formula::class) && observer.defaultToRealFormula) {
                 return FormulaManagerFactoryImpl().createChildManager(formula, input, transitionLock)
             }

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -11,7 +11,7 @@ import io.reactivex.Observable
 import kotlin.reflect.KClass
 
 class TestFormulaObserver<Input : Any, RenderModel : Any, FormulaT : Formula<Input, *, RenderModel>>(
-    private val testManagers: Map<KClass<*>, TestFormulaManager<*, *, *>>,
+    private val testManagers: Map<KClass<*>, TestFormulaManager<*, *>>,
     private val input: Observable<Input>,
     val formula: FormulaT,
     private val defaultToRealFormula: Boolean = true
@@ -77,12 +77,12 @@ class TestFormulaObserver<Input : Any, RenderModel : Any, FormulaT : Formula<Inp
     @PublishedApi
     internal fun <Input, State, RenderModel> findManager(
         type: KClass<out Formula<Input, State, RenderModel>>
-    ): TestFormulaManager<Input, State, RenderModel> {
+    ): TestFormulaManager<Input, RenderModel> {
         val manager = checkNotNull(testManagers[type]) {
             "missing manager registration for $type"
         }
 
         @Suppress("UNCHECKED_CAST")
-        return manager as TestFormulaManager<Input, State, RenderModel>
+        return manager as TestFormulaManager<Input, RenderModel>
     }
 }

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -71,7 +71,8 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
         if (initialization) {
             val processorManager: FormulaManagerImpl<Input, State, RenderModel> =
                 FormulaManagerImpl(
-                    state = formula.initialState(input),
+                    formula = formula,
+                    initialInput = input,
                     callbacks = ScopedCallbacks(formula),
                     transitionLock = lock,
                     childManagerFactory = childManagerFactory

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -117,7 +117,7 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
 
         if (!isValid) {
             val result: Evaluation<RenderModel> =
-                localManager.evaluate(formula, currentInput, processingPass)
+                localManager.evaluate(currentInput, processingPass)
             lastRenderModel = result.renderModel
             emitRenderModel = true
         }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
@@ -10,13 +10,13 @@ import java.lang.IllegalStateException
 class FormulaContextImpl<State> internal constructor(
     private val processingPass: Long,
     callbacks: ScopedCallbacks,
-    private val delegate: Delegate<State>,
+    private val delegate: Delegate,
     private val transitionCallback: TransitionCallbackWrapper<State>
 ) : FormulaContext<State>(callbacks) {
 
     private val childBuilder: Child<State, *, *> = Child<State, Any, Any>(this)
 
-    interface Delegate<State> {
+    interface Delegate {
         fun <ChildInput, ChildState, ChildRenderModel> child(
             formula: Formula<ChildInput, ChildState, ChildRenderModel>,
             input: ChildInput,

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -2,11 +2,8 @@ package com.instacart.formula.internal
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
-import com.instacart.formula.Effects
 
 interface FormulaManager<Input, RenderModel> {
-
-    fun setTransitionListener(listener: (Effects?, isValid: Boolean) -> Unit)
 
     fun updateTransitionNumber(number: Long)
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -4,7 +4,7 @@ import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.Effects
 
-interface FormulaManager<Input, State, RenderModel> {
+interface FormulaManager<Input, RenderModel> {
 
     fun setTransitionListener(listener: (Effects?, isValid: Boolean) -> Unit)
 
@@ -14,7 +14,6 @@ interface FormulaManager<Input, State, RenderModel> {
      * Creates the current [RenderModel] and prepares the next frame that will need to be processed.
      */
     fun evaluate(
-        formula: Formula<Input, State, RenderModel>,
         input: Input,
         transitionId: Long
     ): Evaluation<RenderModel>

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactory.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactory.kt
@@ -7,6 +7,7 @@ interface FormulaManagerFactory {
     fun <Input, State, RenderModel> createChildManager(
         formula: Formula<Input, State, RenderModel>,
         input: Input,
-        transitionLock: TransitionLock
+        transitionLock: TransitionLock,
+        transitionListener: TransitionListener
     ): FormulaManager<Input, RenderModel>
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactory.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactory.kt
@@ -8,5 +8,5 @@ interface FormulaManagerFactory {
         formula: Formula<Input, State, RenderModel>,
         input: Input,
         transitionLock: TransitionLock
-    ): FormulaManager<Input, State, RenderModel>
+    ): FormulaManager<Input, RenderModel>
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
@@ -8,7 +8,7 @@ class FormulaManagerFactoryImpl : FormulaManagerFactory {
         formula: Formula<Input, State, RenderModel>,
         input: Input,
         transitionLock: TransitionLock
-    ): FormulaManager<Input, State, RenderModel> {
+    ): FormulaManager<Input, RenderModel> {
         return FormulaManagerImpl(formula, input, ScopedCallbacks(formula), transitionLock, this)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
@@ -9,7 +9,6 @@ class FormulaManagerFactoryImpl : FormulaManagerFactory {
         input: Input,
         transitionLock: TransitionLock
     ): FormulaManager<Input, State, RenderModel> {
-        val initial = formula.initialState(input)
-        return FormulaManagerImpl(initial, ScopedCallbacks(formula), transitionLock, this)
+        return FormulaManagerImpl(formula, input, ScopedCallbacks(formula), transitionLock, this)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerFactoryImpl.kt
@@ -7,8 +7,9 @@ class FormulaManagerFactoryImpl : FormulaManagerFactory {
     override fun <Input, State, RenderModel> createChildManager(
         formula: Formula<Input, State, RenderModel>,
         input: Input,
-        transitionLock: TransitionLock
+        transitionLock: TransitionLock,
+        transitionListener: TransitionListener
     ): FormulaManager<Input, RenderModel> {
-        return FormulaManagerImpl(formula, input, ScopedCallbacks(formula), transitionLock, this)
+        return FormulaManagerImpl(formula, input, ScopedCallbacks(formula), transitionLock, this, transitionListener)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -21,7 +21,7 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
     private val transitionLock: TransitionLock,
     private val childManagerFactory: FormulaManagerFactory,
     transitionListener: TransitionListener
-) : FormulaContextImpl.Delegate<State>, FormulaManager<Input, RenderModel> {
+) : FormulaContextImpl.Delegate, FormulaManager<Input, RenderModel> {
 
     private val updateManager = UpdateManager(transitionLock)
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -15,7 +15,8 @@ import com.instacart.formula.Transition
  * 4. Prepare parent and alive children for updates.
  */
 internal class FormulaManagerImpl<Input, State, RenderModel>(
-    state: State,
+    private val formula: Formula<Input, State, RenderModel>,
+    initialInput: Input,
     private val callbacks: ScopedCallbacks,
     private val transitionLock: TransitionLock,
     private val childManagerFactory: FormulaManagerFactory
@@ -27,7 +28,7 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
     internal var frame: Frame<Input, State, RenderModel>? = null
     private var terminated = false
 
-    private var state: State = state
+    private var state: State = formula.initialState(initialInput) // state
     private var onTransition: ((Effects?, isValid: Boolean) -> Unit)? = null
     private var pendingRemoval: MutableList<FormulaManager<*, *, *>>? = null
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -179,7 +179,7 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
                 childManagerFactory.createChildManager(formula, input, transitionLock, childTransitionListener)
             }
             .requestAccess {
-                throw java.lang.IllegalStateException("There already is a child with same key: $key. Use [key: Any] parameter.")
+                throw IllegalStateException("There already is a child with same key: $key. Use [key: Any] parameter.")
             } as FormulaManager<ChildInput, ChildRenderModel>
 
         return manager.evaluate(input, processingPass).renderModel

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -20,17 +20,17 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
     private val callbacks: ScopedCallbacks,
     private val transitionLock: TransitionLock,
     private val childManagerFactory: FormulaManagerFactory
-) : FormulaContextImpl.Delegate<State>, FormulaManager<Input, State, RenderModel> {
+) : FormulaContextImpl.Delegate<State>, FormulaManager<Input, RenderModel> {
 
     private val updateManager = UpdateManager(transitionLock)
 
-    internal val children: SingleRequestMap<Any, FormulaManager<*, *, *>> = mutableMapOf()
+    internal val children: SingleRequestMap<Any, FormulaManager<*, *>> = mutableMapOf()
     internal var frame: Frame<Input, State, RenderModel>? = null
     private var terminated = false
 
-    private var state: State = formula.initialState(initialInput) // state
+    private var state: State = formula.initialState(initialInput)
     private var onTransition: ((Effects?, isValid: Boolean) -> Unit)? = null
-    private var pendingRemoval: MutableList<FormulaManager<*, *, *>>? = null
+    private var pendingRemoval: MutableList<FormulaManager<*, *>>? = null
 
     private fun handleTransition(transition: Transition<State>, wasChildInvalidated: Boolean) {
         if (terminated) {
@@ -65,7 +65,6 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
      * Creates the current [RenderModel] and prepares the next frame that will need to be processed.
      */
     override fun evaluate(
-        formula: Formula<Input, State, RenderModel>,
         input: Input,
         transitionId: Long
     ): Evaluation<RenderModel> {
@@ -185,9 +184,9 @@ internal class FormulaManagerImpl<Input, State, RenderModel>(
             }
             .requestAccess {
                 throw java.lang.IllegalStateException("There already is a child with same key: $key. Use [key: String] parameter.")
-            } as FormulaManager<ChildInput, ChildState, ChildRenderModel>
+            } as FormulaManager<ChildInput, ChildRenderModel>
 
-        return manager.evaluate(formula, input, processingPass).renderModel
+        return manager.evaluate(input, processingPass).renderModel
     }
 
     override fun markAsTerminated() {

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionListener.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionListener.kt
@@ -1,0 +1,17 @@
+package com.instacart.formula.internal
+
+import com.instacart.formula.Effects
+
+interface TransitionListener {
+    companion object {
+        inline operator fun invoke(crossinline listener: (Effects?, isValid: Boolean) -> Unit): TransitionListener {
+            return object : TransitionListener {
+                override fun onTransition(effects: Effects?, isValid: Boolean) {
+                    listener(effects, isValid)
+                }
+            }
+        }
+    }
+
+    fun onTransition(effects: Effects?, isValid: Boolean)
+}

--- a/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
@@ -15,8 +15,9 @@ class FormulaManagerChildrenTest {
 
         val formula = OptionalChildFormula(StreamFormula())
         val transitionLock = TransitionLockImpl()
-        val manager = FormulaManagerImpl<Unit, OptionalChildFormula.State, OptionalChildFormula.RenderModel<StreamFormula.RenderModel>>(
-            OptionalChildFormula.State(),
+        val manager = FormulaManagerImpl(
+            formula = formula,
+            initialInput = Unit,
             callbacks = ScopedCallbacks(formula),
             transitionLock = transitionLock,
             childManagerFactory = FormulaManagerFactoryImpl()

--- a/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
@@ -27,12 +27,12 @@ class FormulaManagerChildrenTest {
             transitionLock.next()
         }
 
-        val result = manager.evaluate(formula, Unit, transitionLock.processingPass)
+        val result = manager.evaluate(Unit, transitionLock.processingPass)
         assertThat(manager.children[JoinedKey("", StreamFormula::class)]).isNotNull()
 
         result.renderModel.toggleChild()
 
-        val next = manager.evaluate(formula, Unit, transitionLock.processingPass)
+        val next = manager.evaluate(Unit, transitionLock.processingPass)
         assertThat(next.renderModel.child).isNull()
 
         assertThat(manager.children[JoinedKey("", StreamFormula::class)]).isNull()

--- a/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
@@ -5,6 +5,7 @@ import com.instacart.formula.internal.FormulaManagerFactoryImpl
 import com.instacart.formula.internal.FormulaManagerImpl
 import com.instacart.formula.internal.JoinedKey
 import com.instacart.formula.internal.ScopedCallbacks
+import com.instacart.formula.internal.TransitionListener
 import com.instacart.formula.internal.TransitionLockImpl
 import org.junit.Test
 
@@ -20,12 +21,11 @@ class FormulaManagerChildrenTest {
             initialInput = Unit,
             callbacks = ScopedCallbacks(formula),
             transitionLock = transitionLock,
-            childManagerFactory = FormulaManagerFactoryImpl()
+            childManagerFactory = FormulaManagerFactoryImpl(),
+            transitionListener = TransitionListener { effects, isValid ->
+                transitionLock.next()
+            }
         )
-
-        manager.setTransitionListener { list, isValid ->
-            transitionLock.next()
-        }
 
         val result = manager.evaluate(Unit, transitionLock.processingPass)
         assertThat(manager.children[JoinedKey("", StreamFormula::class)]).isNotNull()


### PR DESCRIPTION
## Changes
Cleaning up the internals a little bit.

- Move `formula.initialState` call into `FormulaManager`.
- Remove `formula` from `FormulaManager.evaluate` call.
- Remove `State` generic from `FormulaManager` interface.