### PR TITLE
Fix crash when multiple fragments get removed in same "backstackChanged" callback

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ commands:
       - run:
           name: Assemble Todo App
           command: |
-            ./gradlew :samples:todoapp:assembleRelease
+            ./gradlew :samples:todoapp:assembleRelease --no-daemon
       - run:
           name: Assemble Custom Stream App
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,11 +97,11 @@ commands:
       - run:
           name: Assemble Counter
           command: |
-            ./gradlew :samples:counter:assembleRelease
+            ./gradlew :samples:counter:assembleRelease --no-daemon
       - run:
           name: Assemble Stopwatch Sample
           command: |
-            ./gradlew :samples:stopwatch:assembleRelease
+            ./gradlew :samples:stopwatch:assembleRelease --no-daemon
       - run:
           name: Assemble Todo App
           command: |
@@ -109,7 +109,7 @@ commands:
       - run:
           name: Assemble Custom Stream App
           command: |
-            ./gradlew :samples:custom-network-state-stream:assembleRelease
+            ./gradlew :samples:custom-network-state-stream:assembleRelease --no-daemon
 
 executors:
   android:

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt
@@ -54,9 +54,7 @@ internal class FragmentFlowRenderView(
             super.onFragmentViewCreated(fm, f, v, savedInstanceState)
 
             if (!stateRestored) {
-                for (i in 0 until activity.supportFragmentManager.backStackEntryCount) {
-                    backStackEntries.add(activity.supportFragmentManager.getBackStackEntryAt(i))
-                }
+                recordBackstackChange()
                 stateRestored = true
             }
 
@@ -176,11 +174,13 @@ internal class FragmentFlowRenderView(
         val backStackEntryCount = backStackEntries.size
         val newBackStackEntryCount = activity.supportFragmentManager.backStackEntryCount
         if (backStackEntryCount > newBackStackEntryCount) {
-            for (i in newBackStackEntryCount until backStackEntryCount) {
-                val poppedFragmentName = backStackEntries.removeAt(i).name
+            val removedEntries = backStackEntries.drop(newBackStackEntryCount)
+            removedEntries.forEach { removed ->
+                val poppedFragmentName = removed.name
                 if (poppedFragmentName != null && visibleFragments.find { it.tag == poppedFragmentName } != null) {
                     awaitingRemoval.add(poppedFragmentName)
                 }
+                backStackEntries.remove(removed)
             }
         } else if (backStackEntryCount < newBackStackEntryCount) {
             for (i in backStackEntryCount until newBackStackEntryCount) {


### PR DESCRIPTION
Looks like https://github.com/instacart/formula/blob/master/formula-android/src/main/java/com/instacart/formula/integration/FragmentFlowRenderView.kt#L180 has been causing a couple of `IndexOutOfBoundException` crashes. 
~Might be caused by some race (and `OnBackStackChangedListener` called from multiple threads)~
Most likely caused by the loop removing elements in "order" and list size decreasing while looping