### PR TITLE
Fix effect execution order.

### DIFF
--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityLifecycleEventTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityLifecycleEventTest.kt
@@ -54,6 +54,6 @@ class ActivityLifecycleEventTest {
         val lifecycle = listOf(CREATED, STARTED, RESUMED, STARTED, CREATED, DESTROYED)
         // We expect two full lifecycles
         val expected = listOf(INITIALIZED) + lifecycle + lifecycle
-        assertThat(events).containsExactlyElementsIn(expected)
+        assertThat(events).containsExactlyElementsIn(expected).inOrder()
     }
 }

--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTest.kt
@@ -57,7 +57,7 @@ class ActivityUpdateTest {
         updateRelay.accept("update-1")
         updateRelay.accept("update-2")
 
-        assertThat(updates()).containsExactly("update-1", "update-2")
+        assertThat(updates()).containsExactly("update-1", "update-2").inOrder()
     }
 
     @Test fun `last update is applied after configuration changes`() {
@@ -66,7 +66,7 @@ class ActivityUpdateTest {
 
         scenario.recreate()
 
-        assertThat(updates()).containsExactly("update-2")
+        assertThat(updates()).containsExactly("update-2").inOrder()
     }
 
     @Test fun `updates are unsubscribed from when activity is finished`() {

--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTimingTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTimingTest.kt
@@ -58,6 +58,6 @@ class ActivityUpdateTimingTest {
 
     @Test fun `last update arrives`() {
         val updates = scenario.get { updates }
-        assertThat(updates).containsExactly("update-2")
+        assertThat(updates).containsExactly("update-2").inOrder()
     }
 }

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
@@ -52,6 +52,7 @@ class FragmentAndroidEventTest {
     @Test fun `activity result`() {
         FormulaAndroid.onActivityResult(scenario.activity(), 1, 2, null)
 
-        assertThat(activityResults).containsExactly(ActivityResult(1, 2, null))
+        val expected = listOf(ActivityResult(1, 2, null))
+        assertThat(activityResults).isEqualTo(expected)
     }
 }

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -63,14 +63,14 @@ class FragmentFlowRenderViewTest {
     }
 
     @Test fun `add fragment lifecycle event`() {
-        assertThat(activeContracts()).containsExactly(TestContract())
+        assertThat(activeContracts()).containsExactly(TestContract()).inOrder()
     }
 
     @Test fun `pop backstack lifecycle event`() {
         navigateToTaskDetail()
         navigateBack()
 
-        assertThat(activeContracts()).containsExactly(TestContract())
+        assertThat(activeContracts()).containsExactly(TestContract()).inOrder()
     }
 
     @Test fun `navigating forward should have both keys in backstack`() {
@@ -79,7 +79,7 @@ class FragmentFlowRenderViewTest {
         assertThat(activeContracts()).containsExactly(
             TestContract(),
             TestContractWithId(1)
-        )
+        ).inOrder()
     }
 
     @Test fun `ignore headless fragments`() {
@@ -92,13 +92,13 @@ class FragmentFlowRenderViewTest {
         }
 
         assertVisibleContract(TestContract())
-        assertThat(activeContracts()).containsExactly(TestContract())
+        assertThat(activeContracts()).containsExactly(TestContract()).inOrder()
     }
 
     @Test fun `render model is passed to visible fragment`() {
         val activity = activity()
         sendStateUpdate(TestContract(), "update")
-        assertThat(activity.renderCalls).containsExactly(TestContract() to "update")
+        assertThat(activity.renderCalls).containsExactly(TestContract() to "update").inOrder()
     }
 
     @Test fun `render model is not passed to not visible fragment`() {
@@ -116,12 +116,12 @@ class FragmentFlowRenderViewTest {
 
         val activity = activity()
         sendStateUpdate(contract, "update")
-        assertThat(activity.renderCalls).containsExactly(contract to "update")
+        assertThat(activity.renderCalls).containsExactly(contract to "update").inOrder()
 
         navigateBack()
 
         sendStateUpdate(contract, "update-two")
-        assertThat(activity.renderCalls).containsExactly(contract to "update")
+        assertThat(activity.renderCalls).containsExactly(contract to "update").inOrder()
     }
 
     @Test fun `delegates back press to current render model`() {
@@ -154,7 +154,7 @@ class FragmentFlowRenderViewTest {
 
         assertVisibleContract(TestContractWithId(1))
         // Both contracts should be active.
-        assertThat(activeContracts()).containsExactly(TestContract(), TestContractWithId(1))
+        assertThat(activeContracts()).containsExactly(TestContract(), TestContractWithId(1)).inOrder()
     }
 
     @Test fun `process death imitation`() {
@@ -172,12 +172,12 @@ class FragmentFlowRenderViewTest {
         // When activity is recreated, it first triggers current fragment and
         // then loads ones from backstack
         assertVisibleContract(TestContractWithId(1))
-        assertThat(activeContracts()).containsExactly(TestContractWithId(1), TestContract())
+        assertThat(activeContracts()).containsExactly(TestContractWithId(1), TestContract()).inOrder()
 
         navigateBack()
 
         assertVisibleContract(TestContract())
-        assertThat(activeContracts()).containsExactly(TestContract())
+        assertThat(activeContracts()).containsExactly(TestContract()).inOrder()
     }
 
     private fun navigateBack() {

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
@@ -59,12 +59,12 @@ class FragmentLifecycleStateTest {
 
     @Test fun `is fragment started`() {
         val events = selectStartedEvents(TestContract())
-        assertThat(events).containsExactly(false, true)
+        assertThat(events).containsExactly(false, true).inOrder()
     }
 
     @Test fun `is fragment resumed`() {
         val events = selectResumedEvents(TestContract())
-        assertThat(events).containsExactly(false, true)
+        assertThat(events).containsExactly(false, true).inOrder()
     }
 
     @Test fun `navigate forward`() {
@@ -73,11 +73,11 @@ class FragmentLifecycleStateTest {
         val contract = TestContract()
         val detail = TestContractWithId(1)
 
-        assertThat(selectStartedEvents(contract)).containsExactly(false, true, false)
-        assertThat(selectResumedEvents(contract)).containsExactly(false, true, false)
+        assertThat(selectStartedEvents(contract)).containsExactly(false, true, false).inOrder()
+        assertThat(selectResumedEvents(contract)).containsExactly(false, true, false).inOrder()
 
-        assertThat(selectStartedEvents(detail)).containsExactly(false, true)
-        assertThat(selectResumedEvents(detail)).containsExactly(false, true)
+        assertThat(selectStartedEvents(detail)).containsExactly(false, true).inOrder()
+        assertThat(selectResumedEvents(detail)).containsExactly(false, true).inOrder()
     }
 
     private fun selectStartedEvents(contract: FragmentContract<*>): List<Boolean> {

--- a/formula-test/src/test/java/com/instacart/formula/test/TestStreamTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestStreamTest.kt
@@ -25,7 +25,7 @@ class TestStreamTest {
     inline fun fails(action: () -> Unit): Throwable {
         try {
             action()
-        } catch (t: Exception) {
+        } catch (t: Error) {
             return t
         }
 

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -81,7 +81,7 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
                         threadChecker.check("Only thread that created it can trigger transitions.")
 
                         if (effects != null) {
-                            effectQueue.push(effects)
+                            effectQueue.addLast(effects)
                         }
 
                         process(isValid)

--- a/formula/src/test/java/com/instacart/formula/DynamicStreamSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/DynamicStreamSubject.kt
@@ -18,7 +18,7 @@ class DynamicStreamSubject {
     }
 
     private fun assertRunning(vararg keys: String) = apply {
-        assertThat(subject.formula.running).containsExactly(*keys)
+        assertThat(subject.formula.running).containsExactly(*keys).inOrder()
     }
 
     class TestFormula : StatelessFormula<List<String>, Unit>() {

--- a/formula/src/test/java/com/instacart/formula/EffectsTimingTest.kt
+++ b/formula/src/test/java/com/instacart/formula/EffectsTimingTest.kt
@@ -21,7 +21,7 @@ class EffectsTimingTest {
             .test(input)
             .renderModel { trigger() }
             .renderModel {
-                assertThat(events).containsExactly(State.INTERNAL, State.EXTERNAL)
+                assertThat(events).containsExactly(State.INTERNAL, State.EXTERNAL).inOrder()
             }
     }
 

--- a/formula/src/test/java/com/instacart/formula/FakeDbSideEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FakeDbSideEffectTest.kt
@@ -18,7 +18,7 @@ class FakeDbSideEffectTest {
             .test()
             .assertNoErrors()
 
-        Truth.assertThat(saveCalls).containsExactly("first", "second", "third", "third")
+        Truth.assertThat(saveCalls).containsExactly("first", "second", "third", "third").inOrder()
     }
 
     class TestFormula(

--- a/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
@@ -16,7 +16,8 @@ class FetchDataExampleTest {
                 values().last().onChangeId("2")
             }
             .apply {
-                assertThat(values().map { it.title }).containsExactly("", "response: 1", "response: 2")
+                val expected = listOf("", "response: 1", "response: 2")
+                assertThat(values().map { it.title }).isEqualTo(expected)
             }
     }
 

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -20,7 +20,8 @@ class FormulaRuntimeTest {
             .apply { formula.incrementEvents.triggerIncrement() }
             .apply { formula.incrementEvents.triggerIncrement() }
             .apply {
-                assertThat(values().map { it.state }).containsExactly(0, 0, 1, 2, 3)
+                val expected = listOf(0, 0, 1, 2, 3)
+                assertThat(values().map { it.state }).isEqualTo(expected)
             }
     }
 
@@ -34,7 +35,8 @@ class FormulaRuntimeTest {
             .apply { formula.incrementEvents.triggerIncrement() }
             .apply { formula.incrementEvents.triggerIncrement() }
             .apply {
-                assertThat(values().map { it.state }).containsExactly(0, 0, 1, 1)
+                val expected = listOf(0, 0, 1, 1)
+                assertThat(values().map { it.state }).isEqualTo(expected)
             }
     }
 
@@ -265,7 +267,7 @@ class FormulaRuntimeTest {
                 callback?.invoke()
             }
             .apply {
-                assertThat(values().map { it.state }).containsExactly(0, 1, 1)
+                assertThat(values().map { it.state }).containsExactly(0, 1, 1).inOrder()
             }
     }
 
@@ -292,7 +294,7 @@ class FormulaRuntimeTest {
                 callback?.invoke(5)
             }
             .apply {
-                assertThat(values().map { it.state }).containsExactly(0, 1, 1)
+                assertThat(values().map { it.state }).containsExactly(0, 1, 1).inOrder()
             }
     }
 
@@ -357,7 +359,7 @@ class FormulaRuntimeTest {
         StreamInputFormula()
             .test(input = Observable.range(0, 3))
             .apply {
-                assertThat(formula.messages).containsExactly(0, 1, 2)
+                assertThat(formula.messages).containsExactly(0, 1, 2).inOrder()
             }
     }
 
@@ -366,7 +368,7 @@ class FormulaRuntimeTest {
         StreamInputFormula()
             .test(input = Observable.just(0, 0, 0, 0))
             .apply {
-                assertThat(formula.messages).containsExactly(0)
+                assertThat(formula.messages).containsExactly(0).inOrder()
             }
     }
 
@@ -614,7 +616,7 @@ class FormulaRuntimeTest {
                 assertThat(onItem.values()).containsExactly(
                     FromObservableWithInputFormula.Item("1"),
                     FromObservableWithInputFormula.Item("2")
-                )
+                ).inOrder()
             }
     }
 

--- a/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
+++ b/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
@@ -10,7 +10,8 @@ class InputChangedTest {
             values().last().onChildNameChanged("first")
             values().last().onChildNameChanged("second")
         }.apply {
-            assertThat(values().map { it.childName }).containsExactly("default", "first", "second")
+            val expected = listOf("default", "first", "second")
+            assertThat(values().map { it.childName }).isEqualTo(expected)
         }
     }
 

--- a/formula/src/test/java/com/instacart/formula/ManyEmissionStreamTest.kt
+++ b/formula/src/test/java/com/instacart/formula/ManyEmissionStreamTest.kt
@@ -14,7 +14,7 @@ class ManyEmissionStreamTest {
         TestFormula()
             .test()
             .apply {
-                assertThat(values()).containsExactly(EMISSION_COUNT)
+                assertThat(values()).containsExactly(EMISSION_COUNT).inOrder()
             }
     }
 

--- a/formula/src/test/java/com/instacart/formula/MultipleEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/MultipleEffectTest.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.MultipleEffectTest.TestFormula2.Event
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.test.test
 import io.reactivex.Observable
@@ -13,9 +14,71 @@ class MultipleEffectTest {
         TestFormula()
             .test(TestFormula.Input(trigger = triggerEventHandler))
             .apply {
-                assertThat(triggerEventHandler.values()).containsExactly(0, 1, 2, 3)
+                val expected = listOf(0, 1, 2, 3)
+                assertThat(triggerEventHandler.values()).isEqualTo(expected)
             }
     }
+
+    @Test fun `multiple effect order maintained across multiple event streams`() {
+        // A state transition has a side effect and triggers another state transition which triggers a side-effect
+
+        val onEvent = TestEventCallback<Event>()
+        TestFormula2()
+            .test(TestFormula2.Input(onEvent = onEvent))
+            .renderModel { start(1) }
+
+        val expected = listOf(Event.Started(1), Event.Stopped(1))
+        assertThat(onEvent.values()).isEqualTo(expected)
+    }
+
+    class TestFormula2 : Formula<TestFormula2.Input, TestFormula2.State, TestFormula2.RenderModel> {
+        sealed class Event {
+            data class Started(val id: Int): Event()
+            data class Stopped(val id: Int): Event()
+        }
+
+        data class Input(
+            val onEvent: (Event) -> Unit
+        )
+
+
+        data class State(
+            val started: List<Int> = emptyList()
+        )
+
+        data class RenderModel(
+            val start: (Int) -> Unit
+        )
+
+        override fun initialState(input: Input): State = State()
+
+        override fun evaluate(
+            input: Input,
+            state: State,
+            context: FormulaContext<State>
+        ): Evaluation<RenderModel> {
+            val started = state.started
+            return Evaluation(
+                renderModel = RenderModel(
+                    start = context.eventCallback {
+                        transition(state.copy(started = started.plus(it))) {
+                            input.onEvent(Event.Started(it))
+                        }
+                    }
+                ),
+                updates = context.updates {
+                    for (id in started) {
+                        events(Stream.onData(id)) {
+                            transition(state.copy(started = started.minus(id))) {
+                                input.onEvent(Event.Stopped(id))
+                            }
+                        }
+                    }
+                }
+            )
+        }
+    }
+
 
     class TestFormula : Formula<TestFormula.Input, Int, Unit> {
 

--- a/formula/src/test/java/com/instacart/formula/RendererTest.kt
+++ b/formula/src/test/java/com/instacart/formula/RendererTest.kt
@@ -97,7 +97,8 @@ class RendererTest {
         }
 
         fun assertRenderedValues(vararg values: T) {
-            assertThat(results).containsExactly(*values)
+            val expected = values.toList()
+            assertThat(results).isEqualTo(expected)
         }
     }
 }


### PR DESCRIPTION
## What
Effects should be executed on a first come first serve basis. Currently, in some cases, it might execute them on last come first serve which can lead to unpredictable behavior. 

While adding a new test, I found out that by default, `assertThat().containsExactly()` doesn't assert on the order. To fix this we either need to append `.inOrder()` or call `isEqualTo(listOf())`. A few tests started failing once we started to assert on order.