### PR TITLE
Move start from extension to interface method

### DIFF
--- a/formula/src/main/java/com/instacart/formula/Formula.kt
+++ b/formula/src/main/java/com/instacart/formula/Formula.kt
@@ -1,5 +1,7 @@
 package com.instacart.formula
 
+import io.reactivex.rxjava3.core.Observable
+
 /**
  * Formula interface defines render model management.
  *
@@ -44,4 +46,20 @@ interface Formula<Input, State, RenderModel> {
         state: State,
         context: FormulaContext<State>
     ): Evaluation<RenderModel>
+
+    fun start(): Observable<RenderModel> {
+        return start(input = Unit as Input)
+    }
+
+    fun start(
+        input: Input
+    ): Observable<RenderModel> {
+        return start(input = Observable.just(input))
+    }
+
+    fun start(
+        input: Observable<Input>
+    ): Observable<RenderModel> {
+        return FormulaRuntime.start(input = input, formula = this)
+    }
 }

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -15,7 +15,7 @@ import java.util.LinkedList
 /**
  * Takes a [Formula] and creates an Observable<RenderModel> from it.
  */
-class FormulaRuntime<Input : Any, State, RenderModel : Any>(
+class FormulaRuntime<Input, State, RenderModel>(
     private val threadChecker: ThreadChecker,
     private val formula: Formula<Input, State, RenderModel>,
     private val childManagerFactory: FormulaManagerFactory,
@@ -26,7 +26,7 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
         /**
          * RuntimeExtensions.kt [start] calls this method.
          */
-        fun <Input : Any, State,  RenderModel : Any> start(
+        fun <Input, State,  RenderModel> start(
             input: Observable<Input>,
             formula: Formula<Input, State, RenderModel>,
             childManagerFactory: FormulaManagerFactory = FormulaManagerFactoryImpl()
@@ -106,7 +106,7 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
      */
     private fun process(isValid: Boolean) {
         val localManager = checkNotNull(manager)
-        val currentInput = checkNotNull(input)
+        val currentInput = checkAnyNotNull(input)
 
         val processingPass = if (isValid) {
             lock.processingPass
@@ -133,7 +133,7 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
 
         if (hasInitialFinished && emitRenderModel) {
             emitRenderModel = false
-            onRenderModel(checkNotNull(lastRenderModel))
+            onRenderModel(checkAnyNotNull(lastRenderModel))
         }
     }
 
@@ -152,5 +152,9 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
                 effects()
             }
         }
+    }
+
+    private fun <T> checkAnyNotNull(value: T?): T {
+        return checkNotNull(value as Any?) as T
     }
 }

--- a/formula/src/main/java/com/instacart/formula/RuntimeExtensions.kt
+++ b/formula/src/main/java/com/instacart/formula/RuntimeExtensions.kt
@@ -1,17 +1,22 @@
+@file:Suppress("DeprecatedCallableAddReplaceWith")
+
 package com.instacart.formula
 
 import io.reactivex.rxjava3.core.Observable
 
+@Deprecated("Call Formula.start instead (remove thie com.instacart.formula.start import)")
 fun <State, RenderModel : Any> Formula<Unit, State, RenderModel>.start(): Observable<RenderModel> {
     return start(input = Unit)
 }
 
+@Deprecated("Call Formula.start instead (remove thie com.instacart.formula.start import)")
 fun <Input : Any, State, RenderModel : Any> Formula<Input, State, RenderModel>.start(
     input: Input
 ): Observable<RenderModel> {
     return start(input = Observable.just(input))
 }
 
+@Deprecated("Call Formula.start instead (remove thie com.instacart.formula.start import)")
 fun <Input : Any, State, RenderModel : Any> Formula<Input, State, RenderModel>.start(
     input: Observable<Input>
 ): Observable<RenderModel> {

--- a/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
+++ b/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
@@ -4,6 +4,7 @@ import com.examples.todoapp.data.Task
 import com.examples.todoapp.data.TaskRepo
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.test.test
+import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.whenever
 import io.reactivex.rxjava3.core.Observable
@@ -11,7 +12,8 @@ import org.junit.Test
 
 class TaskListFormulaTest {
 
-    @Test fun `change filter type`() {
+    @Test
+    fun `change filter type`() {
         val repo = mock<TaskRepo>()
         whenever(repo.tasks()).thenReturn(Observable.just(
             listOf(
@@ -30,6 +32,22 @@ class TaskListFormulaTest {
             }
             .renderModel {
                 assertThat(items).isEmpty()
+            }
+    }
+
+    @Test
+    fun `change formula output`() {
+        val formula = mock<TaskListFormula>()
+        val filterOption = TaskFilterRenderModel(title = "test", onSelected = {})
+        whenever(formula.start(any<TaskListFormula.Input>())).thenReturn(
+            Observable.just(TaskListRenderModel(items = emptyList(), filterOptions = listOf(filterOption)))
+        )
+        formula.start(TaskListFormula.Input { })
+            .test()
+            .assertValueAt(0) {
+                it.items.isEmpty() &&
+                it.filterOptions.size == 1 &&
+                it.filterOptions.first().title == "test"
             }
     }
 }


### PR DESCRIPTION
Presently, it is difficult to mock the entire output of a Formula using Mockito, due to `start` being an extension method, instead of an actual method on the `Formula` interface. Something like this:
```
val formula = mock<TaskListFormula>()
whenever(formula.start(any<TaskListFormula.Input>())).thenReturn(
   Observable.just(TaskListRenderModel(items = emptyList(), filterOptions = emptyList()))
)
```
would throw this exception:
```
java.lang.IllegalArgumentException: Parameter specified as non-null is null: method com.instacart.formula.RuntimeExtensionsKt.start, parameter input
	at com.instacart.formula.RuntimeExtensionsKt.start(RuntimeExtensions.kt)
	at com.examples.todoapp.tasks.TaskListFormulaTest.test start override(TaskListFormulaTest.kt:40)
```
With the introduction of Java 8 compilation, we can move the methods within `RuntimeExtensions.kt` into the `Formula` class, and therefore mock them easily (see [here](https://github.com/instacart/formula/compare/jawn/start-as-method?expand=1#diff-e0909e85cf9a0b62ed86651c37c81281R39))