### PR TITLE
Mockk extension example

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -8,6 +8,7 @@ ext {
     junitVersion = "4.12"
     mockitoVersion = "2.22.0"
     mockitoKotlinVersion = "1.6.0"
+    mockkVersion = "1.10.0"
     okhttpVersion = "3.13.1"
     robolectricVersion = "4.1" // be aware of updating https://github.com/robolectric/robolectric/pull/4736
     truthVersion = "1.0"
@@ -52,6 +53,7 @@ ext {
             rxjava               : "io.reactivex.rxjava3:rxjava:3.0.4",
             rxandroid            : "io.reactivex.rxjava3:rxandroid:3.0.0",
             rxrelays             : "com.jakewharton.rxrelay3:rxrelay:3.0.0",
-            truth                : "com.google.truth:truth:$truthVersion"
+            truth                : "com.google.truth:truth:$truthVersion",
+            mockk                : "io.mockk:mockk:$mockkVersion"
     ]
 }

--- a/samples/todoapp/build.gradle
+++ b/samples/todoapp/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "com.nhaarman:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation libraries.mockk
     testImplementation project(":formula-test")
 
     testImplementation libraries.androidx.test.rules

--- a/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
+++ b/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
@@ -3,21 +3,21 @@ package com.examples.todoapp.tasks
 import com.examples.todoapp.data.Task
 import com.examples.todoapp.data.TaskRepo
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.start
 import com.instacart.formula.test.test
-import com.nhaarman.mockito_kotlin.mock
-import com.nhaarman.mockito_kotlin.whenever
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkStatic
 import io.reactivex.rxjava3.core.Observable
 import org.junit.Test
 
 class TaskListFormulaTest {
 
     @Test fun `change filter type`() {
-        val repo = mock<TaskRepo>()
-        whenever(repo.tasks()).thenReturn(Observable.just(
-            listOf(
-                Task("Mow the lawn."),
-                Task("Go get a haircut.")
-            )
+        val repo = mockk<TaskRepo>()
+        every { repo.tasks() } returns Observable.just(listOf(
+            Task("Mow the lawn."),
+            Task("Go get a haircut.")
         ))
 
         TaskListFormula(repo)
@@ -32,4 +32,21 @@ class TaskListFormulaTest {
                 assertThat(items).isEmpty()
             }
     }
+
+    @Test fun `change formula output`() {
+        val formula = mockk<TaskListFormula>()
+        val filterOption = TaskFilterRenderModel(title = "test", onSelected = {})
+        mockkStatic("com.instacart.formula.RuntimeExtensionsKt")
+        every { formula.start(any<TaskListFormula.Input>()) } returns Observable.just(
+            TaskListRenderModel(items = emptyList(), filterOptions = listOf(filterOption))
+        )
+        formula.start(TaskListFormula.Input { })
+            .test()
+            .assertValueAt(0) {
+                it.items.isEmpty() &&
+                    it.filterOptions.size == 1 &&
+                    it.filterOptions.first().title == "test"
+            }
+    }
+
 }

--- a/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
+++ b/samples/todoapp/src/test/java/com/examples/todoapp/tasks/TaskListFormulaTest.kt
@@ -15,10 +15,12 @@ class TaskListFormulaTest {
 
     @Test fun `change filter type`() {
         val repo = mockk<TaskRepo>()
-        every { repo.tasks() } returns Observable.just(listOf(
+        every { repo.tasks() } returns Observable.just(
+            listOf(
             Task("Mow the lawn."),
             Task("Go get a haircut.")
-        ))
+            )
+        )
 
         TaskListFormula(repo)
             .test(TaskListFormula.Input(showToast = {}))


### PR DESCRIPTION
Follow up to https://github.com/instacart/formula/pull/147. After doing some research, I found that while mockito does not do well with Kotlin extensions, [Mockk](https://github.com/mockk/mockk) is able to handle them well. This adds an example of providing a mock for a formula, overriding its output via mocking the extension. 

I think adding this as an example will be a good reference for those who might run into this.