### PR TITLE
Add reflect dependency to remove warning

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -6,11 +6,11 @@ ext {
 
     espressoVersion = "3.1.1"
     junitVersion = "4.12"
-    mockitoVersion = "2.22.0"
+    mockitoVersion = "3.3.3"
     mockitoKotlinVersion = "1.6.0"
     okhttpVersion = "3.13.1"
     robolectricVersion = "4.1" // be aware of updating https://github.com/robolectric/robolectric/pull/4736
-    truthVersion = "1.0"
+    truthVersion = "1.0.1"
 
     libraries = [
             androidx             : [
@@ -48,6 +48,7 @@ ext {
             ],
             junit                : "junit:junit:$junitVersion",
             kotlin               : "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlinVersion",
+            kotlinReflect        : "org.jetbrains.kotlin:kotlin-reflect:$kotlinVersion",
             robolectric          : "org.robolectric:robolectric:$robolectricVersion",
             rxjava               : "io.reactivex.rxjava3:rxjava:3.0.4",
             rxandroid            : "io.reactivex.rxjava3:rxandroid:3.0.0",

--- a/formula-android/build.gradle
+++ b/formula-android/build.gradle
@@ -62,8 +62,6 @@ dependencies {
     implementation libraries.androidx.annotation
     implementation libraries.androidx.appcompat
 
-    api libraries.kotlinReflect
-
     api libraries.rxandroid
     api libraries.rxrelays
 
@@ -74,4 +72,5 @@ dependencies {
     testImplementation libraries.truth
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "com.nhaarman:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation libraries.kotlinReflect
 }

--- a/formula-android/build.gradle
+++ b/formula-android/build.gradle
@@ -62,6 +62,8 @@ dependencies {
     implementation libraries.androidx.annotation
     implementation libraries.androidx.appcompat
 
+    api libraries.kotlinReflect
+
     api libraries.rxandroid
     api libraries.rxrelays
 

--- a/samples/todoapp/build.gradle
+++ b/samples/todoapp/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     testImplementation "com.google.truth:truth:$truthVersion"
     testImplementation "org.mockito:mockito-inline:$mockitoVersion"
     testImplementation "com.nhaarman:mockito-kotlin:$mockitoKotlinVersion"
+    testImplementation libraries.kotlinReflect
     testImplementation project(":formula-test")
 
     testImplementation libraries.androidx.test.rules


### PR DESCRIPTION
Currently, when you build, you will see this:
```
w: Runtime JAR files in the classpath should have the same version. These files were found in the classpath:
    /Users/johncarlson/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-jdk7/1.3.72/3adfc2f4ea4243e01204be8081fe63bde6b12815/kotlin-stdlib-jdk7-1.3.72.jar (version 1.3)
    /Users/johncarlson/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-reflect/1.0.7/6f22345ea29cd01ec1da04bd28996360bcff05ae/kotlin-reflect-1.0.7.jar (version 1.0)
    /Users/johncarlson/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib/1.3.72/8032138f12c0180bc4e51fe139d4c52b46db6109/kotlin-stdlib-1.3.72.jar (version 1.3)
    /Users/johncarlson/.gradle/caches/modules-2/files-2.1/org.jetbrains.kotlin/kotlin-stdlib-common/1.3.72/6ca8bee3d88957eaaaef077c41c908c9940492d8/kotlin-stdlib-common-1.3.72.jar (version 1.3)
w: Consider providing an explicit dependency on kotlin-reflect 1.3 to prevent strange errors
w: Some runtime JAR files in the classpath have an incompatible version. Consider removing them from the classpath
```
This adds the reflect dependency explicitly, so that it stays up to date with the overall Kotlin version. 