### PR TITLE
Potential fix for Java 8 build failure

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -9,7 +9,7 @@ import com.instacart.formula.internal.TransitionListener
 import com.instacart.formula.internal.TransitionLockImpl
 import io.reactivex.rxjava3.core.Observable
 import io.reactivex.rxjava3.disposables.CompositeDisposable
-import io.reactivex.rxjava3.disposables.Disposable
+import io.reactivex.rxjava3.disposables.FormulaDisposableHelper
 import java.util.LinkedList
 
 /**
@@ -43,10 +43,11 @@ class FormulaRuntime<Input : Any, State, RenderModel : Any>(
                     runtime.onInput(input)
                 }, emitter::onError))
 
-                disposables.add(Disposable.fromRunnable {
+                val runnable = Runnable {
                     threadChecker.check("Need to unsubscribe on the main thread.")
                     runtime.manager?.terminate()
-                })
+                }
+                disposables.add(FormulaDisposableHelper.fromRunnable(runnable))
 
                 emitter.setDisposable(disposables)
             }.distinctUntilChanged()

--- a/formula/src/main/java/io/reactivex/rxjava3/disposables/FormulaDisposableHelper.kt
+++ b/formula/src/main/java/io/reactivex/rxjava3/disposables/FormulaDisposableHelper.kt
@@ -5,7 +5,7 @@ import java.util.Objects
 /**
  * Used due to issue with [Disposable.fromRunnable], please ignore outside of the internal library.
  */
-object FormulaDisposableHelper {
+internal object FormulaDisposableHelper {
 
     /**
      * Identical to [Disposable.fromRunnable]

--- a/formula/src/main/java/io/reactivex/rxjava3/disposables/FormulaDisposableHelper.kt
+++ b/formula/src/main/java/io/reactivex/rxjava3/disposables/FormulaDisposableHelper.kt
@@ -1,0 +1,17 @@
+package io.reactivex.rxjava3.disposables
+
+import java.util.Objects
+
+/**
+ * Used due to issue with [Disposable.fromRunnable], please ignore outside of the internal library.
+ */
+object FormulaDisposableHelper {
+
+    /**
+     * Identical to [Disposable.fromRunnable]
+     */
+    fun fromRunnable(run: Runnable): Disposable {
+        Objects.requireNonNull<Runnable>(run, "run is null")
+        return RunnableDisposable(run)
+    }
+}


### PR DESCRIPTION
Using `Disposible.fromRunnable` within Firebase Test Lab causes issues that are unknown at this time. See https://stackoverflow.com/questions/62762831/no-static-method-fromrunnable-when-running-tests-in-firebase-test-lab

We can likely undo this change later on, but I wanted to run tests with this in place and see if it fixes the issue for us. 