### PR TITLE
Fixing mockito example.

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,8 +35,8 @@ can emit an output, check data passed by the parent or pass events back to the p
 val testFormula = TestFormula<MyFormula.Input, MyFormula.Output>(
     initialOutput = MyFormula.Output()
 )
-// We use spy to ensure that it calls other real methods.
-val formula = spy<MyFormula>()
+// We only want to override the `implementation()` function and keep default `type()`.
+val formula = mock<MyFormula>(defaultAnswer = CallsRealMethods())
 whenever(formula.implementation()).thenReturn(testFormula)
 ```
   

--- a/formula-android/src/test/java/com/instacart/formula/MockitoFormulaTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/MockitoFormulaTest.kt
@@ -1,15 +1,17 @@
 package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.spy
 import com.nhaarman.mockito_kotlin.whenever
 import org.junit.Test
+import org.mockito.internal.stubbing.answers.CallsRealMethods
 
 class MockitoFormulaTest {
 
     @Test fun mockMaintainsType() {
         val testFormula = ReplacementFormula().implementation()
-        val formula = spy<MyFormula>()
+        val formula = mock<MyFormula>(defaultAnswer = CallsRealMethods())
         whenever(formula.implementation()).thenReturn(testFormula)
         assertThat(formula.implementation()).isEqualTo(testFormula)
         assertThat(formula.type()).isEqualTo(MyFormula::class)


### PR DESCRIPTION
## What
To ensure that `type()` is maintained, we need to add `defaultAnswer = CallsRealMethods()`.