### PR TITLE
Lazily initialize internal data structures.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/internal/Callbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/Callbacks.kt
@@ -1,8 +1,8 @@
 package com.instacart.formula.internal
 
 internal class Callbacks {
-    private val callbacks: SingleRequestMap<Any, Callback> = mutableMapOf()
-    private val eventCallbacks: SingleRequestMap<Any, EventCallback<*>> = mutableMapOf()
+    private var callbacks: SingleRequestMap<Any, Callback>? = null
+    private var eventCallbacks: SingleRequestMap<Any, EventCallback<*>>? = null
 
     private fun duplicateKeyErrorMessage(key: Any): String {
         if (key is String) {
@@ -14,6 +14,12 @@ internal class Callbacks {
     }
 
     fun initOrFindCallback(key: Any): Callback {
+        val callbacks = callbacks ?: run {
+            val initialized: SingleRequestMap<Any, Callback> = mutableMapOf()
+            this.callbacks = initialized
+            initialized
+        }
+
         return callbacks
             .findOrInit(key) { Callback(key) }
             .requestAccess {
@@ -23,6 +29,12 @@ internal class Callbacks {
 
     @Suppress("UNCHECKED_CAST")
     fun <UIEvent> initOrFindEventCallback(key: Any): EventCallback<UIEvent> {
+        val eventCallbacks = eventCallbacks ?: run {
+            val initialized: SingleRequestMap<Any, EventCallback<*>> = mutableMapOf()
+            this.eventCallbacks = initialized
+            initialized
+        }
+
         return eventCallbacks
             .findOrInit(key) { EventCallback<UIEvent>(key) }
             .requestAccess {
@@ -31,13 +43,13 @@ internal class Callbacks {
     }
 
     fun evaluationFinished() {
-        callbacks.clearUnrequested {
+        callbacks?.clearUnrequested {
             it.callback = {
                 // TODO log that disabled callback was invoked.
             }
         }
 
-        eventCallbacks.clearUnrequested {
+        eventCallbacks?.clearUnrequested {
             it.callback = {
                 // TODO log that disabled callback was invoked.
             }
@@ -45,18 +57,18 @@ internal class Callbacks {
     }
 
     fun disableAll() {
-        callbacks.forEachValue {
+        callbacks?.forEachValue {
             it.callback = {
                 // TODO log that event is invalid because child was removed
             }
         }
-        callbacks.clear()
+        callbacks?.clear()
 
-        eventCallbacks.forEachValue { entry ->
+        eventCallbacks?.forEachValue { entry ->
             entry.callback = {
                 // TODO log that event is invalid because child was removed
             }
         }
-        eventCallbacks.clear()
+        eventCallbacks?.clear()
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -8,7 +8,7 @@ internal class ScopedCallbacks private constructor(
 ) {
     constructor(formula: IFormula<*, *>) : this(formula::class)
 
-    private val callbacks: SingleRequestMap<Any, Callbacks> = mutableMapOf()
+    private var callbacks: SingleRequestMap<Any, Callbacks>? = null
 
     private var lastCallbacks: Callbacks? = null
     private var lastKey: Any? = null
@@ -60,16 +60,19 @@ internal class ScopedCallbacks private constructor(
     fun evaluationFinished() {
         enabled = false
 
-        val iterator = callbacks.iterator()
-        while (iterator.hasNext()) {
-            val entry = iterator.next()
-            if (!entry.value.requested) {
-                entry.value.value.disableAll()
-                iterator.remove()
-            } else {
-                val callbacks = entry.value.value
-                callbacks.evaluationFinished()
-                entry.value.requested = false
+        val callbacks = callbacks
+        if (callbacks != null) {
+            val iterator = callbacks.iterator()
+            while (iterator.hasNext()) {
+                val entry = iterator.next()
+                if (!entry.value.requested) {
+                    entry.value.value.disableAll()
+                    iterator.remove()
+                } else {
+                    val callbacks = entry.value.value
+                    callbacks.evaluationFinished()
+                    entry.value.requested = false
+                }
             }
         }
 
@@ -77,13 +80,18 @@ internal class ScopedCallbacks private constructor(
     }
 
     fun disableAll() {
-        callbacks.forEachValue {
+        callbacks?.forEachValue {
             it.disableAll()
         }
-        callbacks.clear()
+        callbacks?.clear()
     }
 
     private fun currentCallbacks(): Callbacks {
+        val callbacks = callbacks ?: run {
+            val initialized: SingleRequestMap<Any, Callbacks> = mutableMapOf()
+            this.callbacks = initialized
+            initialized
+        }
         return current ?: callbacks
             .findOrInit(currentKey) { Callbacks() }
             .requestAccess { "Duplicate key: $currentKey" }

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -60,9 +60,8 @@ internal class ScopedCallbacks private constructor(
     fun evaluationFinished() {
         enabled = false
 
-        val callbacks = callbacks
-        if (callbacks != null) {
-            val iterator = callbacks.iterator()
+        val iterator = callbacks?.iterator()
+        if (iterator != null) {
             while (iterator.hasNext()) {
                 val entry = iterator.next()
                 if (!entry.value.requested) {

--- a/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaManagerChildrenTest.kt
@@ -25,13 +25,13 @@ class FormulaManagerChildrenTest {
 
         val result = manager.evaluate(Unit, transitionLock.processingPass)
         val formulaKey = FormulaKey(StreamFormula::class, null)
-        assertThat(manager.children[formulaKey]).isNotNull()
+        assertThat(manager.children!![formulaKey]).isNotNull()
 
         result.output.toggleChild()
 
         val next = manager.evaluate(Unit, transitionLock.processingPass)
         assertThat(next.output.child).isNull()
 
-        assertThat(manager.children[formulaKey]).isNull()
+        assertThat(manager.children!![formulaKey]).isNull()
     }
 }


### PR DESCRIPTION
## What
To minimize memory consumption, only initialize Map/Set data-structures when they are needed.