### PR TITLE
[bugfix] Fix runtime ignoring  for the root formula.

### DIFF
--- a/.buildscript/jacoco-workaround.gradle
+++ b/.buildscript/jacoco-workaround.gradle
@@ -1,0 +1,6 @@
+apply plugin: "jacoco"
+
+// Fixing issue: https://github.com/gradle/gradle/issues/5184
+tasks.withType(Test) {
+    jacoco.excludes = ['jdk.internal.*']
+}

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -119,7 +119,7 @@ executors:
     working_directory: ~/code
     environment:
       # Java is really greedy, let's minimize how much memory it takes
-      JAVA_TOOL_OPTIONS: '-Xmx512m -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap -XX:MaxRAMFraction=1'
+      JAVA_TOOL_OPTIONS: '-Xmx512m'
       GRADLE_OPTS: '-Dorg.gradle.jvmargs="-Xmx6g -XX:+HeapDumpOnOutOfMemoryError"'
       JVM_OPTS: '-Xmx3200m'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Changelog
+## [0.6.1] - TBD
+- Bugfix: Fix runtime ignoring `Formula.key` for the root formula.
+
 ## [0.6.0] - July 27, 2020
 - **Breaking**: Changing from RxJava 2.x to RxJava 3.x
 - Change callback key type from String to Any.

--- a/formula-android-tests/build.gradle
+++ b/formula-android-tests/build.gradle
@@ -2,6 +2,8 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 
+apply from: rootProject.file('.buildscript/jacoco-workaround.gradle')
+
 androidExtensions {
     experimental = true
     features = ['parcelize']

--- a/formula-android/build.gradle
+++ b/formula-android/build.gradle
@@ -8,6 +8,7 @@ apply plugin: "com.vanniktech.maven.publish"
 
 apply from: rootProject.file('.buildscript/configure-dokka.gradle')
 apply from: rootProject.file('.buildscript/configure-signing.gradle')
+apply from: rootProject.file('.buildscript/jacoco-workaround.gradle')
 
 androidExtensions {
     experimental = true

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -657,4 +657,15 @@ class FormulaRuntimeTest {
             .test()
             .assertError { it is java.lang.IllegalStateException && it.message.orEmpty().startsWith("Nested scopes are not supported currently.") }
     }
+
+    @Test
+    fun `formula key is used to reset root formula state`() {
+        RootFormulaKeyTestSubject()
+            .assertValue(0)
+            .increment()
+            .increment()
+            .assertValue(2)
+            .resetKey()
+            .assertValue(0)
+    }
 }

--- a/formula/src/test/java/com/instacart/formula/RootFormulaKeyTestSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/RootFormulaKeyTestSubject.kt
@@ -1,0 +1,53 @@
+package com.instacart.formula
+
+import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.test.test
+import com.jakewharton.rxrelay3.BehaviorRelay
+
+class RootFormulaKeyTestSubject {
+
+    private val inputRelay = BehaviorRelay.createDefault(0)
+    private val subject = MyFormula.test(inputRelay)
+
+    fun increment() = apply {
+        subject.output { increment() }
+    }
+
+    fun assertValue(value: Int) = apply {
+        subject.output {
+            assertThat(this.value).isEqualTo(value)
+        }
+    }
+
+    fun resetKey() = apply {
+        inputRelay.accept(inputRelay.value + 1)
+    }
+
+
+    data class Output(
+        val value: Int,
+        val increment: () -> Unit
+    )
+
+    object MyFormula : Formula<Int, Int, Output> {
+        override fun initialState(input: Int): Int = 0
+
+        // We reset formula whenever key changes.
+        override fun key(input: Int): Any? = input
+
+        override fun evaluate(
+            input: Int,
+            state: Int,
+            context: FormulaContext<Int>
+        ): Evaluation<Output> {
+            return Evaluation(
+                output = Output(
+                    value = state,
+                    increment = context.callback {
+                        transition(state + 1)
+                    }
+                )
+            )
+        }
+    }
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.6-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## What
Currently, we only respect `Formula.key()` for child formulas, but we also need to add this logic for root formulas started using `FormulaRuntime.start()`.