### PR TITLE
[formula-android] adding main thread check before notifying fragment.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 ## [0.6.1] - TBD
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.
+- [formula-android] Adding main thread check before notifying fragments. 
 
 ## [0.6.0] - July 27, 2020
 - **Breaking**: Changing from RxJava 2.x to RxJava 3.x

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -61,6 +61,8 @@ internal class ActivityManager<Activity : FragmentActivity>(
         delegate.onLifecycleStateChanged(Lifecycle.State.CREATED)
         val renderView = fragmentRenderView ?: throw callOnPreCreateException(activity)
         uiSubscription = fragmentState.subscribe {
+            Utils.assertMainThread()
+
             renderView.render(it)
             store.onRenderFragmentState?.invoke(activity, it)
         }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
@@ -1,0 +1,11 @@
+package com.instacart.formula.android.internal
+
+import android.os.Looper
+
+internal object Utils {
+    fun assertMainThread() {
+        if (Looper.getMainLooper() != Looper.myLooper()) {
+            throw IllegalStateException("should be called on main thread: ${Thread.currentThread()}")
+        }
+    }
+}


### PR DESCRIPTION
## What
Adding main thread check to ensure mistakes are caught earlier.