### PR TITLE
Crash on duplicate contracts early.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## [0.6.1] - TBD
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.
 - [formula-android] Adding main thread check before notifying fragments. 
+- **Breaking**: Crash when duplicate fragment contract is registered.
 
 ## [0.6.0] - July 27, 2020
 - **Breaking**: Changing from RxJava 2.x to RxJava 3.x

--- a/formula-android/src/main/java/com/instacart/formula/integration/Binding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/Binding.kt
@@ -25,11 +25,13 @@ abstract class Binding<in ParentComponent, Key> {
 
         fun <ParentComponent, Component, Key : Any> composite(
             scopeFactory: ComponentFactory<ParentComponent, Component>,
-            bindings: List<Binding<Component, Key>>
+            bindings: Bindings<Component, Key>
         ): Binding<ParentComponent, Key> {
-            return CompositeBinding(scopeFactory, bindings)
+            return CompositeBinding(scopeFactory, bindings.types, bindings.bindings)
         }
     }
+
+    internal abstract fun types(): Set<Class<*>>
 
     /**
      * Returns true if this binding handles this [key]

--- a/formula-android/src/main/java/com/instacart/formula/integration/BindingBuilder.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/BindingBuilder.kt
@@ -32,7 +32,7 @@ class BindingBuilder<Component, Key : Any> : BaseBindingBuilder<Component, Key>(
         init: BindingBuilder<NewComponent, Key>.() -> Unit
     ) = apply {
         val scoped = BindingBuilder<NewComponent, Key>().apply(init).build()
-        bind(CompositeBinding(componentFactory, scoped))
+        bind(CompositeBinding(componentFactory, scoped.types, scoped.bindings))
     }
 
     inline fun <reified T : Key> bind(integration: Integration<T, Key, *>) = apply {

--- a/formula-android/src/main/java/com/instacart/formula/integration/Bindings.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/Bindings.kt
@@ -1,0 +1,6 @@
+package com.instacart.formula.integration
+
+class Bindings<Component, Key : Any>(
+    val types: Set<Class<*>>,
+    val bindings: List<Binding<Component, Key>>
+)

--- a/formula-android/src/main/java/com/instacart/formula/integration/FlowDeclaration.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FlowDeclaration.kt
@@ -14,7 +14,7 @@ import com.instacart.formula.fragment.FragmentContract
 abstract class FlowDeclaration<FlowComponent> {
 
     data class Flow<FlowComponent>(
-        val bindings: List<Binding<FlowComponent, FragmentContract<*>>>
+        val bindings: Bindings<FlowComponent, FragmentContract<*>>
     )
 
     /**

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentBindingBuilder.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentBindingBuilder.kt
@@ -15,7 +15,7 @@ class FragmentBindingBuilder<Component> : BaseBindingBuilder<Component, Fragment
         @PublishedApi
         internal inline fun <Component> build(
             init: FragmentBindingBuilder<Component>.() -> Unit
-        ): List<Binding<Component, FragmentContract<*>>> {
+        ): Bindings<Component, FragmentContract<*>> {
             return FragmentBindingBuilder<Component>().apply(init).build()
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/BaseBindingBuilder.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/BaseBindingBuilder.kt
@@ -1,19 +1,32 @@
 package com.instacart.formula.integration.internal
 
 import com.instacart.formula.integration.Binding
+import com.instacart.formula.integration.Bindings
+import java.lang.IllegalStateException
 
 /**
  * Base binding builder used to define type safe builders for specific key types. Take a look
  * at [com.instacart.formula.integration.FragmentBindingBuilder].
  */
 abstract class BaseBindingBuilder<Component, Key : Any> {
+    private val types = mutableSetOf<Class<*>>()
     private val bindings: MutableList<Binding<Component, Key>> = mutableListOf()
 
-    fun bind(binding: Binding<Component, Key>) = apply {
-        bindings.add(binding)
+    internal fun bind(binding: Binding<Component, Key>) = apply {
+        binding.types().forEach {
+            if (types.contains(it)) {
+                throw IllegalStateException("Binding for $it already exists")
+            }
+            types += it
+        }
+
+        bindings += binding
     }
 
-    fun build(): List<Binding<Component, Key>> {
-        return bindings
+    fun build(): Bindings<Component, Key> {
+        return Bindings(
+            types = types,
+            bindings = bindings
+        )
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/CompositeBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/CompositeBinding.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.integration.internal
 
 import com.instacart.formula.integration.BackStack
 import com.instacart.formula.integration.Binding
+import com.instacart.formula.integration.Bindings
 import com.instacart.formula.integration.ComponentFactory
 import com.instacart.formula.integration.FlowEnvironment
 import com.instacart.formula.integration.KeyState
@@ -17,8 +18,11 @@ import io.reactivex.rxjava3.core.Observable
  */
 internal class CompositeBinding<Key: Any, ParentComponent, ScopedComponent>(
     private val scopeFactory: ComponentFactory<ParentComponent, ScopedComponent>,
-    private val bindings: List<Binding<ScopedComponent, Key>>
+    private val types: Set<Class<*>>,
+    val bindings: List<Binding<ScopedComponent, Key>>
 ) : Binding<ParentComponent, Key>() {
+
+    override fun types(): Set<Class<*>> = types
 
     override fun binds(key: Any): Boolean {
         return bindings.any { it.binds(key) }

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/SingleBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/SingleBinding.kt
@@ -31,6 +31,10 @@ internal class SingleBinding<Component, Key, State : Any>(
         }
     }
 
+    override fun types(): Set<Class<*>> {
+        return setOf(type)
+    }
+
     override fun binds(key: Any): Boolean {
         return type.isInstance(key)
     }

--- a/formula-android/src/test/java/com/instacart/formula/integration/FragmentFlowStoreTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/integration/FragmentFlowStoreTest.kt
@@ -106,6 +106,21 @@ class FragmentFlowStoreTest {
             }
     }
 
+    @Test fun `duplicate contract registration throws an exception`() {
+        var exception: Throwable? = null
+        try {
+            FragmentFlowStore.init(AppComponent()) {
+                bind(AuthFlowIntegration())
+                bind(AuthFlowIntegration())
+            }
+        } catch (t: Throwable){
+            exception = t
+        }
+        assertThat(exception?.message).isEqualTo(
+            "Binding for class com.instacart.formula.integration.test.TestLoginFragmentContract already exists"
+        )
+    }
+
     fun createStore(component: AppComponent): FragmentFlowStore {
         return FragmentFlowStore.init(component) {
             bind(AuthFlowIntegration())


### PR DESCRIPTION
## What
Currently, having duplicate registrations could lead to hard to detect issues where multiple formula instances are sending different render models to the same screen.