### PR TITLE
Bugfix: duplicate key is added on activity rotation.

### DIFF
--- a/formula-android-tests/src/test/java/com/instacart/formula/TestFormulaRule.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/TestFormulaRule.kt
@@ -2,8 +2,11 @@ package com.instacart.formula
 
 import android.app.Application
 import androidx.test.core.app.ApplicationProvider
+import com.google.common.truth.Truth
+import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
+import org.junit.runners.model.Statement
 
 /**
  * A rule to initialize FormulaAndroid.
@@ -12,6 +15,21 @@ class TestFormulaRule(
     private val initFormula: (Application) -> Unit,
     private val cleanUp: () -> Unit = {}
 ) : TestWatcher() {
+    private val errors = mutableListOf<Throwable>()
+
+    override fun apply(base: Statement, description: Description): Statement {
+        RxJavaPlugins.reset()
+        RxJavaPlugins.setErrorHandler { errors.add(it) }
+
+        try {
+            val result = super.apply(base, description)
+            assertNoErrors()
+            return result
+        } finally {
+            errors.clear()
+            RxJavaPlugins.reset()
+        }
+    }
 
     override fun starting(description: Description?) {
         super.starting(description)
@@ -32,5 +50,9 @@ class TestFormulaRule(
     private fun initializeFormula() {
         val context = ApplicationProvider.getApplicationContext<Application>()
         initFormula(context)
+    }
+
+    private fun assertNoErrors() {
+        Truth.assertThat(errors).isEmpty()
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
@@ -92,16 +92,21 @@ class FragmentFlowStore(
                             transition(updated)
                         }
                         is LifecycleEvent.Added -> {
-                            // We want to emit an empty state update if key is not handled.
-                            val notHandled = if (!root.binds(key)) {
-                                listOf(Pair(key, KeyState(key, "missing-registration")))
+                            if (!state.activeKeys.contains(key)) {
+                                // We want to emit an empty state update if key is not handled.
+                                val notHandled = if (!root.binds(key)) {
+                                    listOf(Pair(key, KeyState(key, "missing-registration")))
+                                } else {
+                                    emptyList()
+                                }
+
+                                transition(state.copy(
+                                    activeKeys = state.activeKeys.plus(key),
+                                    states = state.states.plus(notHandled)
+                                ))
                             } else {
-                                emptyList()
+                                none()
                             }
-                            transition(state.copy(
-                                activeKeys = state.activeKeys.plus(key),
-                                states = state.states.plus(notHandled)
-                            ))
                         }
                     }
                 }


### PR DESCRIPTION
## What
On activity configuration changes, lifecycle events are fired again for already added fragments. We should not consume them if we already have them in-memory.
