### PR TITLE
Removing state.noEffects() extension.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 - **Breaking**: Remove `events(observable) { }` utility function.
 - Removing `rxjava3` from core module.
 - Moving `key` function into `IFormula`
+- **Breaking**: Remove `state.noEffects()` extension function. Use `transition(state)` instead.
 
 ## [0.6.1] - November 18, 2020
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.

--- a/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
@@ -59,7 +59,7 @@ class TestFormulaTest {
                     button = context.child(childFormula, ChildFormula.Input(
                         name = state.name,
                         onChangeName = context.eventCallback {
-                            state.copy(name = it).noEffects()
+                            transition(state.copy(name = it))
                         }
                     ))
                 )

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -54,12 +54,5 @@ data class Transition<out State> @PublishedApi internal constructor(
         ): Transition<Nothing> {
             return transition(null, invokeEffects)
         }
-
-        /**
-         * Creates a transition to a new [State] with no additional side-effects.
-         */
-        fun <State> State.noEffects(): Transition<State> {
-            return transition(this)
-        }
     }
 }

--- a/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
@@ -54,13 +54,13 @@ class FetchDataExampleTest {
                 output = Output(
                     title = state.response?.name ?: "",
                     onChangeId = context.eventCallback { id ->
-                        state.copy(selectedId = id).noEffects()
+                        transition(state.copy(selectedId = id))
                     }
                 ),
                 updates = context.updates {
                     if (state.selectedId != null) {
                         events(dataRepo.fetch(state.selectedId)) { response ->
-                            state.copy(response = response).noEffects()
+                            transition(state.copy(response = response))
                         }
                     }
                 }

--- a/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
+++ b/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
@@ -32,7 +32,7 @@ class InputChangedTest {
                 output = Output(
                     childName = context.child(childFormula, state),
                     onChildNameChanged = context.eventCallback { name ->
-                        name.noEffects()
+                        transition(name)
                     }
                 )
             )

--- a/formula/src/test/java/com/instacart/formula/KeyUsingListFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/KeyUsingListFormula.kt
@@ -29,7 +29,7 @@ class KeyUsingListFormula : Formula<KeyUsingListFormula.Input, KeyUsingListFormu
         val items = state.items.map { itemName ->
             context.key(itemName) {
                 ItemRenderModel(itemName, onDeleteSelected = context.callback {
-                    state.copy(items = state.items.minus(itemName)).noEffects()
+                    transition(state.copy(items = state.items.minus(itemName)))
                 })
             }
         }

--- a/formula/src/test/java/com/instacart/formula/OptionalCallbackFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/OptionalCallbackFormula.kt
@@ -16,7 +16,7 @@ class OptionalCallbackFormula : Formula<Unit, OptionalCallbackFormula.State, Opt
 
     override fun evaluate(input: Unit, state: State, context: FormulaContext<State>): Evaluation<Output> {
         val callback = if (state.callbackEnabled) {
-            context.callback { state.copy(state = state.state + 1).noEffects() }
+            context.callback { transition(state.copy(state = state.state + 1)) }
         } else {
             null
         }
@@ -26,7 +26,7 @@ class OptionalCallbackFormula : Formula<Unit, OptionalCallbackFormula.State, Opt
                 state = state.state,
                 callback = callback,
                 toggleCallback = context.callback {
-                    state.copy(callbackEnabled = !state.callbackEnabled).noEffects()
+                    transition(state.copy(callbackEnabled = !state.callbackEnabled))
                 }
             )
         )

--- a/formula/src/test/java/com/instacart/formula/OptionalChildFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/OptionalChildFormula.kt
@@ -36,7 +36,7 @@ class OptionalChildFormula<ChildInput, ChildOutput>(
             output = Output(
                 child = childOutput,
                 toggleChild = context.callback {
-                    state.copy(showChild = !state.showChild).noEffects()
+                    transition(state.copy(showChild = !state.showChild))
                 }
             )
         )

--- a/formula/src/test/java/com/instacart/formula/OptionalEventCallbackFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/OptionalEventCallbackFormula.kt
@@ -17,7 +17,7 @@ class OptionalEventCallbackFormula : Formula<Unit, OptionalEventCallbackFormula.
     override fun evaluate(input: Unit, state: State, context: FormulaContext<State>): Evaluation<Output> {
         val callback = if (state.callbackEnabled) {
             context.eventCallback<Int> {
-                state.copy(state = it).noEffects()
+                transition(state.copy(state = it))
             }
         } else {
             null
@@ -28,7 +28,7 @@ class OptionalEventCallbackFormula : Formula<Unit, OptionalEventCallbackFormula.
                 state = state.state,
                 callback = callback,
                 toggleCallback = context.callback {
-                    state.copy(callbackEnabled = !state.callbackEnabled).noEffects()
+                    transition(state.copy(callbackEnabled = !state.callbackEnabled))
                 }
             )
         )

--- a/formula/src/test/java/com/instacart/formula/StreamFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/StreamFormula.kt
@@ -26,17 +26,17 @@ class StreamFormula : Formula<Unit, StreamFormula.State, StreamFormula.Output> {
             updates = context.updates {
                 if (state.listenForEvents) {
                     events(incrementEvents.stream()) {
-                        state.copy(count = state.count + 1).noEffects()
+                        transition(state.copy(count = state.count + 1))
                     }
                 }
             },
             output = Output(
                 state = state.count,
                 startListening = context.callback {
-                    state.copy(listenForEvents = true).noEffects()
+                    transition(state.copy(listenForEvents = true))
                 },
                 stopListening = context.callback {
-                    state.copy(listenForEvents = false).noEffects()
+                    transition(state.copy(listenForEvents = false))
                 }
             )
         )

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListFormula.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListFormula.kt
@@ -49,7 +49,7 @@ class TaskListFormula(private val repo: TaskRepo) : Formula<TaskListFormula.Inpu
         return Evaluation(
             updates = context.updates {
                 RxStream.fromObservable(repo::tasks).onEvent {
-                    state.copy(taskState = it).noEffects()
+                    transition(state.copy(taskState = it))
                 }
             },
             output = TaskListRenderModel(
@@ -78,7 +78,7 @@ class TaskListFormula(private val repo: TaskRepo) : Formula<TaskListFormula.Inpu
                 TaskFilterRenderModel(
                     title = type.name,
                     onSelected = context.callback {
-                        state.copy(filterType = type).noEffects()
+                        transition(state.copy(filterType = type))
                     }
                 )
             }


### PR DESCRIPTION
## What
The philosophy here is that it's best to avoid having multiple ways to do the same thing. The preference is
```kotlin
transition(newState)
```