### PR TITLE
Cleaning up deprecated dependency usage.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/Stream.kt
+++ b/formula/src/main/java/com/instacart/formula/Stream.kt
@@ -42,7 +42,7 @@ interface Stream<Message> {
          * }
          * ```
          */
-        fun <Data : Any> onData(data: Data): Stream<Data> {
+        fun <Data> onData(data: Data): Stream<Data> {
             return StartMessageStream(data)
         }
 
@@ -73,13 +73,13 @@ interface Stream<Message> {
     /**
      * Used to distinguish between different types of Streams.
      */
-    fun key(): Any
+    fun key(): Any?
 }
 
 /**
  * Emits a message as soon as [Stream] is initialized.
  */
-internal class StartMessageStream<Data : Any>(
+internal class StartMessageStream<Data>(
     private val data: Data
 ) : Stream<Data> {
 
@@ -88,14 +88,14 @@ internal class StartMessageStream<Data : Any>(
         return null
     }
 
-    override fun key(): Any = data
+    override fun key(): Any? = data
 }
 
 /**
  * Emits a message when [Formula] is terminated.
  */
 internal object TerminateMessageStream : Stream<Unit> {
-    override fun start(send: (Unit) -> Unit): Cancelable? {
+    override fun start(send: (Unit) -> Unit): Cancelable {
         return Cancelable {
             send(Unit)
         }

--- a/formula/src/test/java/com/instacart/formula/ChildMessageTriggersEventTransitionInParent.kt
+++ b/formula/src/test/java/com/instacart/formula/ChildMessageTriggersEventTransitionInParent.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula
 
+import com.instacart.formula.rxjava3.RxStream
 import com.jakewharton.rxrelay3.PublishRelay
 import io.reactivex.rxjava3.core.Observable
 

--- a/formula/src/test/java/com/instacart/formula/EffectsTimingTest.kt
+++ b/formula/src/test/java/com/instacart/formula/EffectsTimingTest.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.rxjava3.RxStream
 import com.instacart.formula.test.test
 import com.jakewharton.rxrelay3.PublishRelay
 import io.reactivex.rxjava3.core.Observable

--- a/formula/src/test/java/com/instacart/formula/FakeDbSideEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FakeDbSideEffectTest.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula
 
 import com.google.common.truth.Truth
+import com.instacart.formula.rxjava3.RxStream
 import com.instacart.formula.rxjava3.toObservable
 import io.reactivex.rxjava3.core.Observable
 import org.junit.Test

--- a/formula/src/test/java/com/instacart/formula/MultipleEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/MultipleEffectTest.kt
@@ -2,6 +2,7 @@ package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.MultipleEffectTest.TestFormula2.Event
+import com.instacart.formula.rxjava3.RxStream
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.test.test
 import io.reactivex.rxjava3.core.Observable

--- a/formula/src/test/java/com/instacart/formula/RendererTest.kt
+++ b/formula/src/test/java/com/instacart/formula/RendererTest.kt
@@ -66,7 +66,7 @@ class RendererTest {
 
     @Test fun `handling exceptions in rendering`() {
         var crash: Boolean = true
-        val subject = TestSubject<String?> { render, value ->
+        val subject = TestSubject<String?> { _, _ ->
             if (crash) {
                 crash = false
                 throw IllegalStateException("you can't do this")

--- a/formula/src/test/java/com/instacart/formula/SimpleSideEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/SimpleSideEffectTest.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula
 
+import com.instacart.formula.rxjava3.RxStream
 import com.instacart.formula.test.TestCallback
 import com.instacart.formula.test.test
 import io.reactivex.rxjava3.core.Observable

--- a/formula/src/test/java/com/instacart/formula/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
+++ b/formula/src/test/java/com/instacart/formula/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula
 
+import com.instacart.formula.rxjava3.RxStream
 import com.instacart.formula.test.test
 import io.reactivex.rxjava3.core.Observable
 

--- a/formula/src/test/java/com/instacart/formula/internal/TestExtensions.kt
+++ b/formula/src/test/java/com/instacart/formula/internal/TestExtensions.kt
@@ -1,6 +1,0 @@
-package com.instacart.formula.internal
-
-
-fun <A> safeRun(function: () -> A) {
-
-}


### PR DESCRIPTION
## What
- Removing `Any` from `Stream.onData()` requirement.
- Cleaning up deprecated `RxStream` usages.