### PR TITLE
Allow nullable formula states.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 - Moving `key` function into `IFormula`
 - **Breaking**: Remove `state.noEffects()` extension function. Use `transition(state)` instead.
 - Added `StreamFormula` and `ObservableFormula`.
+- Allow nullable formula state.
 
 ## [0.6.1] - November 18, 2020
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.

--- a/formula/src/main/java/com/instacart/formula/Formula.kt
+++ b/formula/src/main/java/com/instacart/formula/Formula.kt
@@ -13,7 +13,7 @@ package com.instacart.formula
  * @param Output A data class returned by this formula that contains data and callbacks. When it is
  * used to render UI, we call it a render model (Ex: ItemRenderModel).
  */
-interface Formula<in Input, State : Any, out Output> : IFormula<Input, Output> {
+interface Formula<in Input, State, out Output> : IFormula<Input, Output> {
 
     /**
      * Creates the initial [state][State] to be used in [evaluation][Formula.evaluate]. This

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -41,11 +41,11 @@ class FormulaRuntime<Input : Any, Output : Any>(
         this.key = formula.key(input)
 
         if (initialization) {
-            val transitionListener = TransitionListener { effects, isValid ->
+            val transitionListener = TransitionListener { transition, isValid ->
                 threadChecker.check("Only thread that created it can trigger transitions.")
 
-                if (effects != null) {
-                    effectQueue.addLast(effects)
+                transition.effects?.let {
+                    effectQueue.addLast(it)
                 }
 
                 run(shouldEvaluate = !isValid)

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -2,14 +2,8 @@ package com.instacart.formula
 
 /**
  * Defines an intent to transition by emitting a new [State] and optional [Effects].
- *
- * @param state Updated state
- * @param effects Optional effects such as parent callbacks / logging / db writes/ network requests / etc.
  */
-data class Transition<out State> @PublishedApi internal constructor(
-    val state: State? = null,
-    val effects: Effects? = null
-) {
+sealed class Transition<out State> {
     companion object {
         /**
          * A convenience method to define transitions.
@@ -20,19 +14,46 @@ data class Transition<out State> @PublishedApi internal constructor(
          * }
          * ```
          */
-        inline fun <State> create(init: Factory.() -> Transition<State>): Transition<State> {
+        inline fun <State, T: Transition<State>> create(init: Factory.() -> T): T {
             return init(Factory)
         }
     }
 
+    /**
+     * Stateful transition.
+     *
+     * @param state New state
+     * @param effects Optional effects such as parent callbacks,
+     * logging, db writes, network requests, etc.
+     */
+    data class Stateful<State>(val state: State, override val effects: Effects? = null) : Transition<State>()
+
+    /**
+     * Only effects are emitted as part of this transition
+     *
+     * @param effects Effects such as parent callbacks,
+     * logging, db writes, network requests, etc.
+     */
+    data class OnlyEffects(override val effects: Effects) : Transition<Nothing>()
+
+    /**
+     * Nothing happens in this transition.
+     */
+    object None : Transition<Nothing>() {
+        override val effects: Effects? = null
+    }
+
+
+    /**
+     * Factory uses as a receiver parameter to provide transition constructor dsl.
+     */
     object Factory {
-        private val NONE = Transition<Nothing>()
 
         /**
          * A transition that does nothing.
          */
         fun none(): Transition<Nothing> {
-            return NONE
+            return None
         }
 
         /**
@@ -40,10 +61,10 @@ data class Transition<out State> @PublishedApi internal constructor(
          * after the state change.
          */
         fun <State> transition(
-            state: State? = null,
+            state: State,
             invokeEffects: (() -> Unit)? = null
-        ): Transition<State> {
-            return Transition(state, invokeEffects)
+        ): Stateful<State> {
+            return Stateful(state, invokeEffects)
         }
 
         /**
@@ -51,8 +72,10 @@ data class Transition<out State> @PublishedApi internal constructor(
          */
         fun transition(
             invokeEffects: () -> Unit
-        ): Transition<Nothing> {
-            return transition(null, invokeEffects)
+        ): OnlyEffects {
+            return OnlyEffects(invokeEffects)
         }
     }
+
+    abstract val effects: Effects?
 }

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -14,7 +14,7 @@ sealed class Transition<out State> {
          * }
          * ```
          */
-        inline fun <State, T: Transition<State>> create(init: Factory.() -> T): T {
+        inline fun <State> create(init: Factory.() -> Transition<State>): Transition<State> {
             return init(Factory)
         }
     }

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -23,16 +23,15 @@ sealed class Transition<out State> {
      * Stateful transition.
      *
      * @param state New state
-     * @param effects Optional effects such as parent callbacks,
-     * logging, db writes, network requests, etc.
+     * @param effects Optional effects such as parent callbacks, logging, db writes,
+     * network requests, etc.
      */
     data class Stateful<State>(val state: State, override val effects: Effects? = null) : Transition<State>()
 
     /**
      * Only effects are emitted as part of this transition
      *
-     * @param effects Effects such as parent callbacks,
-     * logging, db writes, network requests, etc.
+     * @param effects Effects such as parent callbacks, logging, db writes, network requests, etc.
      */
     data class OnlyEffects(override val effects: Effects) : Transition<Nothing>()
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -45,9 +45,8 @@ internal class FormulaManagerImpl<Input, State, Output>(
             return
         }
 
-        this.state = when (transition) {
-            is Transition.Stateful -> transition.state
-            else -> this.state
+        if (transition is Transition.Stateful) {
+            state = transition.state
         }
         val frame = this.frame
         frame?.updateStateValidity(state)
@@ -198,16 +197,16 @@ internal class FormulaManagerImpl<Input, State, Output>(
 
     private fun getOrInitChildTransitionListener(): TransitionListener {
         return childTransitionListener ?: run {
-            val listener = TransitionListener { transition, isValid ->
+            TransitionListener { transition, isChildValid ->
                 val frame = this.frame
-                if (!isValid) {
+                if (!isChildValid) {
                     frame?.childInvalidated()
                 }
                 val isValid = frame != null && frame.isValid()
                 transitionListener.onTransition(transition, isValid)
+            }.apply {
+                childTransitionListener = this
             }
-            childTransitionListener = listener
-            listener
         }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionCallbackWrapper.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionCallbackWrapper.kt
@@ -3,7 +3,7 @@ package com.instacart.formula.internal
 import com.instacart.formula.Transition
 
 internal class TransitionCallbackWrapper<State>(
-    private val handleTransition: (Transition<State>, Boolean) -> Unit,
+    private val handleTransition: (Transition<State>) -> Unit,
     var transitionId: TransitionId
 ) : (Transition<State>) -> Unit {
     var running = false
@@ -23,6 +23,6 @@ internal class TransitionCallbackWrapper<State>(
             throw IllegalStateException("Transition already happened. This is using old transition callback: $transition.")
         }
 
-        handleTransition(transition, false)
+        handleTransition(transition)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionListener.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionListener.kt
@@ -1,17 +1,17 @@
 package com.instacart.formula.internal
 
-import com.instacart.formula.Effects
+import com.instacart.formula.Transition
 
 interface TransitionListener {
     companion object {
-        inline operator fun invoke(crossinline listener: (Effects?, isValid: Boolean) -> Unit): TransitionListener {
+        inline operator fun invoke(crossinline listener: (Transition<*>, isValid: Boolean) -> Unit): TransitionListener {
             return object : TransitionListener {
-                override fun onTransition(effects: Effects?, isValid: Boolean) {
-                    listener(effects, isValid)
+                override fun onTransition(transition: Transition<*>, isValid: Boolean) {
+                    listener(transition, isValid)
                 }
             }
         }
     }
 
-    fun onTransition(effects: Effects?, isValid: Boolean)
+    fun onTransition(transition: Transition<*>, isValid: Boolean)
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
@@ -5,6 +5,6 @@ import com.instacart.formula.Transition
 internal object TransitionUtils {
 
     fun isEmpty(transition: Transition<*>): Boolean {
-        return transition.state == null && transition.effects == null
+        return transition == Transition.None
     }
 }

--- a/formula/src/test/java/com/instacart/formula/TerminateFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/TerminateFormula.kt
@@ -22,7 +22,7 @@ class TerminateFormula : StatelessFormula<Unit, Unit>() {
         return WithId(implementation(), original.type(), key)
     }
 
-    internal class WithId<Input, State : Any, Output>(
+    internal class WithId<Input, State, Output>(
         val implementation: Formula<Input, State, Output>,
         val type: KClass<*>,
         val key: Any

--- a/formula/src/test/java/com/instacart/formula/internal/TransitionUtilsTest.kt
+++ b/formula/src/test/java/com/instacart/formula/internal/TransitionUtilsTest.kt
@@ -26,6 +26,8 @@ class TransitionUtilsTest {
             transition("new state")
         }
 
+        transition as Transition.Stateful<String>
+
         assertThat(transition.state).isEqualTo("new state")
     }
 }

--- a/formula/src/test/java/com/instacart/formula/internal/TransitionUtilsTest.kt
+++ b/formula/src/test/java/com/instacart/formula/internal/TransitionUtilsTest.kt
@@ -12,12 +12,12 @@ class TransitionUtilsTest {
     }
 
     @Test fun `state change is not empty`() {
-        val transition = Transition(state = "")
+        val transition = Transition.Stateful(state = "")
         assertThat(TransitionUtils.isEmpty(transition)).isFalse()
     }
 
     @Test fun `transition with messages is not empty`() {
-        val transition = Transition<String>(effects = {})
+        val transition = Transition.OnlyEffects(effects = {})
         assertThat(TransitionUtils.isEmpty(transition)).isFalse()
     }
 

--- a/formula/src/test/java/com/instacart/formula/tests/NullableStateTest.kt
+++ b/formula/src/test/java/com/instacart/formula/tests/NullableStateTest.kt
@@ -1,0 +1,46 @@
+package com.instacart.formula.tests
+
+import com.google.common.truth.Truth
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.FormulaContext
+import com.instacart.formula.test.test
+import org.junit.Test
+
+class NullableStateTest {
+
+    @Test fun `nullable state changes`() {
+        TestFormula()
+            .test()
+            .output { Truth.assertThat(state).isNull() }
+            .output { updateState("new state") }
+            .output { Truth.assertThat(state).isEqualTo("new state") }
+            .output { updateState(null) }
+            .output { Truth.assertThat(state).isNull() }
+    }
+
+    class TestFormula : Formula<Unit, String?, TestFormula.Output> {
+
+        data class Output(
+            val state: String?,
+            val updateState: (String?) -> Unit
+        )
+
+        override fun initialState(input: Unit): String? = null
+
+        override fun evaluate(
+            input: Unit,
+            state: String?,
+            context: FormulaContext<String?>
+        ): Evaluation<Output> {
+            return Evaluation(
+                output = Output(
+                    state = state,
+                    updateState = context.eventCallback {
+                        transition(it)
+                    }
+                )
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What
There is no reason why we shouldn't allow `null` states given that Kotlin type system provides support for it. This will remove the need to wrap nullable states within `Option` type.

- As part of this, I've separated `Transition` into 3 sealed class types. 
- Separated child transition logic - no need to initialize a new `Transition` object when passing it from child to parent.
- Only initialize child transition listener once.