### PR TITLE
Remove FormulaFragment.renderView() function.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Breaking**: Remove `state.noEffects()` extension function. Use `transition(state)` instead.
 - Added `StreamFormula` and `ObservableFormula`.
 - Allow nullable formula state.
+- **Breaking**: Removing `FormulaFragment.renderView()` function
 
 ## [0.6.1] - November 18, 2020
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
@@ -117,8 +117,6 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
         return contract
     }
 
-    fun renderView(): RenderView<RenderModel>? = renderView
-
     fun setEnvironment(environment: FragmentEnvironment) {
         this.fragmentEnvironment = environment
     }


### PR DESCRIPTION
## What
Removing this function, since with compose coming, `RenderView` is not always going to apply to `FormulaFragment`.