### PR TITLE
Adding FragmentKey type.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 - Added `StreamFormula` and `ObservableFormula`.
 - Allow nullable formula state.
 - **Breaking**: Removing `FormulaFragment.renderView()` function
+- **Breaking**: Replace `FormulaFragment.getFragmentContract()` with `getFragmentKey()`. 
+- **Breaking:** Removing generic key parameter from `KeyState`.
 
 ## [0.6.1] - November 18, 2020
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -8,6 +8,7 @@ import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.fragment.FormulaFragment
 import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentFlowState
+import com.instacart.formula.fragment.FragmentKey
 import com.instacart.formula.integration.BackCallback
 import com.instacart.formula.test.TestContract
 import com.instacart.formula.test.TestContractWithId
@@ -202,7 +203,7 @@ class FragmentFlowRenderViewTest {
         return scenario.activity()
     }
 
-    private fun activeContracts(): List<FragmentContract<*>> {
+    private fun activeContracts(): List<FragmentKey> {
         return scenario.get {
             lastState!!.activeKeys
         }

--- a/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
+++ b/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
@@ -7,10 +7,10 @@ import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
 import com.instacart.formula.android.ActivityConfigurator
 import com.instacart.formula.activity.ActivityResult
-import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentEnvironment
 import com.instacart.formula.android.internal.ActivityStoreFactory
 import com.instacart.formula.android.AppManager
+import com.instacart.formula.fragment.FragmentKey
 import java.lang.IllegalStateException
 
 object FormulaAndroid {
@@ -25,7 +25,7 @@ object FormulaAndroid {
      */
     fun init(
         application: Application,
-        onFragmentError: (FragmentContract<*>, Throwable) -> Unit = { _, it -> throw it },
+        onFragmentError: (FragmentKey, Throwable) -> Unit = { _, it -> throw it },
         activities: ActivityConfigurator.() -> Unit
     ) {
         // Should we allow re-initialization?

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -5,6 +5,7 @@ import androidx.lifecycle.Lifecycle
 import com.instacart.formula.activity.ActivityResult
 import com.instacart.formula.fragment.FragmentContract
 import com.instacart.formula.fragment.FragmentFlowState
+import com.instacart.formula.fragment.FragmentKey
 import com.instacart.formula.integration.ActivityStoreContext
 import com.jakewharton.rxrelay3.BehaviorRelay
 import com.jakewharton.rxrelay3.PublishRelay
@@ -96,7 +97,7 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
         attachEventRelay.accept(false)
     }
 
-    fun updateFragmentLifecycleState(contract: FragmentContract<*>, newState: Lifecycle.State) {
+    fun updateFragmentLifecycleState(contract: FragmentKey, newState: Lifecycle.State) {
         if (newState == Lifecycle.State.DESTROYED) {
             fragmentLifecycleStates.remove(contract.tag)
         } else {

--- a/formula-android/src/main/java/com/instacart/formula/fragment/BaseFormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/BaseFormulaFragment.kt
@@ -2,7 +2,7 @@ package com.instacart.formula.fragment
 
 interface BaseFormulaFragment<State> {
 
-    fun getFragmentContract(): FragmentContract<State>
+    fun getFragmentKey(): FragmentKey
 
     fun currentState(): State?
 

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FormulaFragment.kt
@@ -113,7 +113,7 @@ class FormulaFragment<RenderModel> : Fragment(), BaseFormulaFragment<RenderModel
         return stateRelay.value
     }
 
-    override fun getFragmentContract(): FragmentContract<RenderModel> {
+    override fun getFragmentKey(): FragmentKey {
         return contract
     }
 

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentContract.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentContract.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.fragment
 
-import android.os.Parcelable
 import android.view.View
 
 /**
@@ -21,14 +20,7 @@ import android.view.View
  * }
  * ```
  */
-abstract class FragmentContract<in RenderModel> : Parcelable {
-
-    /**
-     * Tag that will be used to determine fragment visibility. This tag should be unique for each contract, though this
-     * is not enforced.
-     */
-    abstract val tag: String
-
+abstract class FragmentContract<in RenderModel> : FragmentKey {
     /**
      * Layout id that defines the view
      */

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentEnvironment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentEnvironment.kt
@@ -1,5 +1,5 @@
 package com.instacart.formula.fragment
 
-import com.instacart.formula.integration.FlowEnvironment
-
-typealias FragmentEnvironment = FlowEnvironment<FragmentContract<*>>
+data class FragmentEnvironment(
+    val onScreenError: (FragmentKey, Throwable) -> Unit = { _, it -> throw it }
+)

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowState.kt
@@ -10,9 +10,9 @@ import com.instacart.formula.integration.KeyState
  * @param states Last emitted state of each active [FragmentContract].
  */
 data class FragmentFlowState(
-    val activeKeys: List<FragmentContract<*>> = emptyList(),
-    val visibleKeys: List<FragmentContract<*>> = emptyList(),
-    val states: Map<FragmentContract<*>, KeyState<FragmentContract<*>>> = emptyMap()
+    val activeKeys: List<FragmentKey> = emptyList(),
+    val visibleKeys: List<FragmentKey> = emptyList(),
+    val states: Map<FragmentKey, KeyState> = emptyMap()
 ) {
     fun visibleState() = visibleKeys.lastOrNull()?.let { states[it] }
 }

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentFlowStore.kt
@@ -17,7 +17,7 @@ import io.reactivex.rxjava3.core.Observable
  * A FragmentFlowStore is responsible for managing the state of multiple [FragmentContract] instances.
  */
 class FragmentFlowStore(
-    private val root: Binding<Unit, FragmentContract<*>>
+    private val root: Binding<Unit>
 ) : Formula<FragmentEnvironment, FragmentFlowState, FragmentFlowState> {
     companion object {
         inline fun init(
@@ -42,8 +42,8 @@ class FragmentFlowStore(
 
 
     private val lifecycleEvents = PublishRelay.create<FragmentLifecycleEvent>()
-    private val visibleContractEvents = PublishRelay.create<FragmentContract<*>>()
-    private val hiddenContractEvents = PublishRelay.create<FragmentContract<*>>()
+    private val visibleContractEvents = PublishRelay.create<FragmentKey>()
+    private val hiddenContractEvents = PublishRelay.create<FragmentKey>()
 
     private val lifecycleEventStream = RxStream.fromObservable { lifecycleEvents }
     private val visibleContractEventStream = RxStream.fromObservable { visibleContractEvents }
@@ -53,7 +53,7 @@ class FragmentFlowStore(
         lifecycleEvents.accept(event)
     }
 
-    internal fun onVisibilityChanged(contract: FragmentContract<*>, visible: Boolean) {
+    internal fun onVisibilityChanged(contract: FragmentKey, visible: Boolean) {
         if (visible) {
             visibleContractEvents.accept(contract)
         } else {

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentKey.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentKey.kt
@@ -1,0 +1,23 @@
+package com.instacart.formula.fragment
+
+import android.os.Parcelable
+import androidx.fragment.app.FragmentManager
+
+/**
+ * A key is used to identify a specific [FormulaFragment].
+ *
+ * ```
+ * data class TaskDetailKey(
+ *   val taskID: String
+ * ) : FragmentKey {
+ *   override val tag: String = "task-detail-$taskId"
+ * }
+ * ```
+ */
+interface FragmentKey : Parcelable {
+
+    /**
+     * Tag is a unique identifier used to distinguish each fragment instance by the [FragmentManager].
+     */
+    val tag: String
+}

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycle.kt
@@ -18,17 +18,17 @@ internal object FragmentLifecycle {
         return !fragment.isRemoving
     }
 
-    internal fun createAddedEvent(f: Fragment): LifecycleEvent.Added<FragmentContract<Nothing>> {
-        return LifecycleEvent.Added(f.getFragmentContract())
+    internal fun createAddedEvent(f: Fragment): LifecycleEvent.Added<FragmentKey> {
+        return LifecycleEvent.Added(f.getFragmentKey())
     }
 
-    internal fun createRemovedEvent(f: Fragment): LifecycleEvent.Removed<FragmentContract<Nothing>> {
+    internal fun createRemovedEvent(f: Fragment): LifecycleEvent.Removed<FragmentKey> {
         val fragment = f as? BaseFormulaFragment<*>
-        return LifecycleEvent.Removed(f.getFragmentContract(), fragment?.currentState())
+        return LifecycleEvent.Removed(f.getFragmentKey(), fragment?.currentState())
     }
 }
 
-internal fun Fragment.getFragmentContract(): FragmentContract<*> {
+internal fun Fragment.getFragmentKey(): FragmentKey {
     val fragment = this as? BaseFormulaFragment<*>
-    return fragment?.getFragmentContract() ?: EmptyFragmentContract(tag.orEmpty())
+    return fragment?.getFragmentKey() ?: EmptyFragmentContract(tag.orEmpty())
 }

--- a/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycleEvent.kt
+++ b/formula-android/src/main/java/com/instacart/formula/fragment/FragmentLifecycleEvent.kt
@@ -2,4 +2,4 @@ package com.instacart.formula.fragment
 
 import com.instacart.formula.integration.LifecycleEvent
 
-typealias FragmentLifecycleEvent = LifecycleEvent<FragmentContract<*>>
+typealias FragmentLifecycleEvent = LifecycleEvent<FragmentKey>

--- a/formula-android/src/main/java/com/instacart/formula/integration/Binding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/Binding.kt
@@ -1,28 +1,29 @@
 package com.instacart.formula.integration
 
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.fragment.FragmentEnvironment
+import com.instacart.formula.fragment.FragmentKey
 import com.instacart.formula.integration.internal.CompositeBinding
 
 /**
  * Defines how specific keys bind to the state management associated
  */
-abstract class Binding<ParentComponent, Key : Any> {
+abstract class Binding<ParentComponent> {
     companion object {
-        fun <ParentComponent, Component, Key : Any> composite(
+        fun <ParentComponent, Component> composite(
             scopeFactory: ComponentFactory<ParentComponent, Component>,
-            bindings: Bindings<Component, Key>
-        ): Binding<ParentComponent, Key> {
+            bindings: Bindings<Component>
+        ): Binding<ParentComponent> {
             return CompositeBinding(scopeFactory, bindings.types, bindings.bindings)
         }
     }
 
-    data class Input<Component, Key : Any>(
-        val environment: FlowEnvironment<Key>,
+    data class Input<Component>(
+        val environment: FragmentEnvironment,
         val component: Component,
-        val activeKeys: List<Key>,
-        val onStateChanged: (KeyState<Key>) -> Unit
+        val activeKeys: List<FragmentKey>,
+        val onStateChanged: (KeyState) -> Unit,
     )
-
 
     internal abstract fun types(): Set<Class<*>>
 
@@ -34,5 +35,5 @@ abstract class Binding<ParentComponent, Key : Any> {
     /**
      * Listens for active key changes and triggers [Input.onStateChanged] events.
      */
-    internal abstract fun bind(context: FormulaContext<*>, input: Input<ParentComponent, Key>)
+    internal abstract fun bind(context: FormulaContext<*>, input: Input<ParentComponent>)
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/Bindings.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/Bindings.kt
@@ -1,6 +1,6 @@
 package com.instacart.formula.integration
 
-class Bindings<Component, Key : Any>(
+class Bindings<Component>(
     val types: Set<Class<*>>,
-    val bindings: List<Binding<Component, Key>>
+    val bindings: List<Binding<Component>>
 )

--- a/formula-android/src/main/java/com/instacart/formula/integration/FlowDeclaration.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FlowDeclaration.kt
@@ -1,7 +1,5 @@
 package com.instacart.formula.integration
 
-import com.instacart.formula.fragment.FragmentContract
-
 /**
  * The FlowDeclaration class defines a [Flow], which is a sequence of related screens a user may navigate
  * between to perform a task. A shared [FlowComponent] is passed to individual screen integrations to help
@@ -14,7 +12,7 @@ import com.instacart.formula.fragment.FragmentContract
 abstract class FlowDeclaration<FlowComponent> {
 
     data class Flow<FlowComponent>(
-        val bindings: Bindings<FlowComponent, FragmentContract<*>>
+        val bindings: Bindings<FlowComponent>
     )
 
     /**

--- a/formula-android/src/main/java/com/instacart/formula/integration/FlowEnvironment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FlowEnvironment.kt
@@ -1,5 +1,0 @@
-package com.instacart.formula.integration
-
-data class FlowEnvironment<in Key>(
-    val onScreenError: (Key, Throwable) -> Unit = { _, it -> throw it }
-)

--- a/formula-android/src/main/java/com/instacart/formula/integration/FlowIntegration.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FlowIntegration.kt
@@ -1,7 +1,5 @@
 package com.instacart.formula.integration
 
-import com.instacart.formula.fragment.FragmentContract
-
 /**
  *
  * The flow integration class defines how a parent should integrate a particular flow. This class takes a
@@ -32,7 +30,7 @@ abstract class FlowIntegration<ParentComponent, FlowComponent> {
 
     protected abstract fun createComponent(parentComponent: ParentComponent): DisposableScope<FlowComponent>
 
-    fun binding(): Binding<ParentComponent, FragmentContract<*>> {
+    fun binding(): Binding<ParentComponent> {
         return Binding.composite(this::createComponent, flowDeclaration.createFlow().bindings)
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/integration/FragmentBindingBuilder.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/FragmentBindingBuilder.kt
@@ -9,13 +9,13 @@ import kotlin.reflect.KClass
 /**
  * Used to create a [Binding] for [FragmentContract] keys.
  */
-class FragmentBindingBuilder<Component> : BaseBindingBuilder<Component, FragmentContract<*>>() {
+class FragmentBindingBuilder<Component> : BaseBindingBuilder<Component>() {
     companion object {
 
         @PublishedApi
         internal inline fun <Component> build(
             init: FragmentBindingBuilder<Component>.() -> Unit
-        ): Bindings<Component, FragmentContract<*>> {
+        ): Bindings<Component> {
             return FragmentBindingBuilder<Component>().apply(init).build()
         }
     }
@@ -31,7 +31,7 @@ class FragmentBindingBuilder<Component> : BaseBindingBuilder<Component, Fragment
         integration: Integration<Component, T, RenderModel>
     ) = apply {
         val binding = SingleBinding(type.java, integration)
-        bind(binding as Binding<Component, FragmentContract<*>>)
+        bind(binding as Binding<Component>)
     }
 
     /**

--- a/formula-android/src/main/java/com/instacart/formula/integration/KeyState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/KeyState.kt
@@ -1,6 +1,8 @@
 package com.instacart.formula.integration
 
+import com.instacart.formula.fragment.FragmentKey
+
 /**
  * Defines the current render model for a specific [key].
  */
-data class KeyState<Key>(val key: Key, val renderModel: Any)
+data class KeyState(val key: FragmentKey, val renderModel: Any)

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/BaseBindingBuilder.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/BaseBindingBuilder.kt
@@ -8,11 +8,11 @@ import java.lang.IllegalStateException
  * Base binding builder used to define type safe builders for specific key types. Take a look
  * at [com.instacart.formula.integration.FragmentBindingBuilder].
  */
-abstract class BaseBindingBuilder<Component, Key : Any> {
+abstract class BaseBindingBuilder<Component> {
     private val types = mutableSetOf<Class<*>>()
-    private val bindings: MutableList<Binding<Component, Key>> = mutableListOf()
+    private val bindings: MutableList<Binding<Component>> = mutableListOf()
 
-    internal fun bind(binding: Binding<Component, Key>) = apply {
+    internal fun bind(binding: Binding<Component>) = apply {
         binding.types().forEach {
             if (types.contains(it)) {
                 throw IllegalStateException("Binding for $it already exists")
@@ -23,7 +23,7 @@ abstract class BaseBindingBuilder<Component, Key : Any> {
         bindings += binding
     }
 
-    fun build(): Bindings<Component, Key> {
+    fun build(): Bindings<Component> {
         return Bindings(
             types = types,
             bindings = bindings

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/CompositeBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/CompositeBinding.kt
@@ -5,7 +5,6 @@ import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
 import com.instacart.formula.Stream
 import com.instacart.formula.integration.Binding
-import com.instacart.formula.integration.Bindings
 import com.instacart.formula.integration.ComponentFactory
 import com.instacart.formula.integration.DisposableScope
 
@@ -17,12 +16,12 @@ import com.instacart.formula.integration.DisposableScope
  * @param ScopedComponent A component that is initialized when user enters this flow and is shared between
  *                  all the screens within the flow. Component will be destroyed when user exists the flow.
  */
-internal class CompositeBinding<Key: Any, ParentComponent, ScopedComponent>(
+internal class CompositeBinding<ParentComponent, ScopedComponent>(
     private val scopeFactory: ComponentFactory<ParentComponent, ScopedComponent>,
     private val types: Set<Class<*>>,
-    private val bindings: List<Binding<ScopedComponent, Key>>
-) : Binding<ParentComponent, Key>(),
-    Formula<Binding.Input<ParentComponent, Key>, CompositeBinding.State<ScopedComponent>, Unit> {
+    private val bindings: List<Binding<ScopedComponent>>
+) : Binding<ParentComponent>(),
+    Formula<Binding.Input<ParentComponent>, CompositeBinding.State<ScopedComponent>, Unit> {
 
     data class State<ScopedComponent>(
         val component: DisposableScope<ScopedComponent>? = null
@@ -37,18 +36,18 @@ internal class CompositeBinding<Key: Any, ParentComponent, ScopedComponent>(
         return false
     }
 
-    override fun bind(context: FormulaContext<*>, input: Input<ParentComponent, Key>) {
+    override fun bind(context: FormulaContext<*>, input: Input<ParentComponent>) {
         context.child(this, input)
     }
 
-    override fun key(input: Input<ParentComponent, Key>): Any? = this
+    override fun key(input: Input<ParentComponent>): Any? = this
 
-    override fun initialState(input: Input<ParentComponent, Key>): State<ScopedComponent> {
+    override fun initialState(input: Input<ParentComponent>): State<ScopedComponent> {
         return State()
     }
 
     override fun evaluate(
-        input: Input<ParentComponent, Key>,
+        input: Input<ParentComponent>,
         state: State<ScopedComponent>,
         context: FormulaContext<State<ScopedComponent>>
     ): Evaluation<Unit> {
@@ -58,7 +57,7 @@ internal class CompositeBinding<Key: Any, ParentComponent, ScopedComponent>(
                 input.environment,
                 component.component,
                 input.activeKeys,
-                input.onStateChanged
+                input.onStateChanged,
             )
             bindings.forEachIndices {
                 it.bind(context, childInput)

--- a/formula-android/src/main/java/com/instacart/formula/integration/internal/SingleBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/integration/internal/SingleBinding.kt
@@ -3,19 +3,20 @@ package com.instacart.formula.integration.internal
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
-import com.instacart.formula.rxjava3.RxStream
+import com.instacart.formula.fragment.FragmentKey
 import com.instacart.formula.integration.Binding
 import com.instacart.formula.integration.Integration
 import com.instacart.formula.integration.KeyState
+import com.instacart.formula.rxjava3.RxStream
 import io.reactivex.rxjava3.core.Observable
 
 /**
  * Defines how a specific key should be bound to its [Integration],
  */
-internal class SingleBinding<Component, Key : Any, State : Any>(
+internal class SingleBinding<Component, Key : FragmentKey, State : Any>(
     private val type: Class<Key>,
     private val integration: Integration<Component, Key, State>
-) : Binding<Component, Key>(), Formula<Binding.Input<Component, Key>, Unit, Unit> {
+) : Binding<Component>(), Formula<Binding.Input<Component>, Unit, Unit> {
 
     override fun types(): Set<Class<*>> {
         return setOf(type)
@@ -25,16 +26,16 @@ internal class SingleBinding<Component, Key : Any, State : Any>(
         return type.isInstance(key)
     }
 
-    override fun bind(context: FormulaContext<*>, input: Input<Component, Key>) {
+    override fun bind(context: FormulaContext<*>, input: Input<Component>) {
         context.child(this, input)
     }
 
-    override fun key(input: Input<Component, Key>): Any? = type
+    override fun key(input: Input<Component>): Any? = type
 
-    override fun initialState(input: Input<Component, Key>) = Unit
+    override fun initialState(input: Input<Component>) = Unit
 
     override fun evaluate(
-        input: Input<Component, Key>,
+        input: Input<Component>,
         state: Unit,
         context: FormulaContext<Unit>
     ): Evaluation<Unit> {
@@ -44,7 +45,7 @@ internal class SingleBinding<Component, Key : Any, State : Any>(
                 input.activeKeys.forEachIndices { key ->
                     if (binds(key)) {
                         val stream = RxStream.fromObservable(key) {
-                            integration.create(input.component, key).onErrorResumeNext {
+                            integration.create(input.component, key as Key).onErrorResumeNext {
                                 input.environment.onScreenError(key, it)
                                 Observable.empty()
                             }

--- a/formula-android/src/test/java/com/instacart/formula/fragment/FragmentFlowStoreTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/fragment/FragmentFlowStoreTest.kt
@@ -100,7 +100,7 @@ class FragmentFlowStoreTest {
     }
 
     private fun expectedState(states: List<Pair<FragmentContract<*>, *>>): FragmentFlowState {
-        val initial = mutableMapOf<FragmentContract<*>, KeyState<FragmentContract<*>>>()
+        val initial = mutableMapOf<FragmentKey, KeyState>()
         val keyStates = states.foldRight(initial) { value, acc ->
             if (value.second != null) {
                 acc.put(value.first, KeyState(value.first, value.second!!))


### PR DESCRIPTION
## What
Adding `FragmentKey` type which only contains `tag` and no UI rendering logic which means it has no generic parameter.
```kotlin
interface FragmentKey : Parcelable {
    abstract val tag: String
}
```

It's a pre-cursor to https://github.com/instacart/formula/pull/181
