### PR TITLE
[Android] Make <in Dependencies> for FlowFactory.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/FlowFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FlowFactory.kt
@@ -42,7 +42,7 @@ import com.instacart.formula.integration.FragmentBindingBuilder
  * @param FlowComponent A component that is initialized when user enters this flow and is shared
  * between all the screens within flow. Component will be destroyed when user exits the flow
  */
-interface FlowFactory<Dependencies, FlowComponent> {
+interface FlowFactory<in Dependencies, FlowComponent> {
 
     /**
      * Using [dependencies] passed by the parent, this function creates a component used by

--- a/formula-android/src/test/java/com/instacart/formula/android/FlowFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/FlowFactoryTest.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula.android
 
 import com.google.common.truth.Truth
+import com.instacart.formula.fragment.FragmentFlowStore
 import com.instacart.formula.integration.Binding
 import com.instacart.formula.integration.DisposableScope
 import com.instacart.formula.integration.test.TestAccountFragmentContract
@@ -32,6 +33,16 @@ class FlowFactoryTest {
         }
     }
 
+    class EmptyFlowFactory<Dependencies> : FlowFactory<Dependencies, Unit> {
+        override fun createComponent(dependencies: Dependencies): DisposableScope<Unit> {
+            return DisposableScope(Unit, {})
+        }
+
+        override fun createFlow(): Flow<Unit> {
+            return Flow.build {  }
+        }
+    }
+
     @Test
     fun `binds only declared contracts`() {
 
@@ -40,5 +51,13 @@ class FlowFactoryTest {
         Truth.assertThat(binding.binds(TestSignUpFragmentContract())).isTrue()
 
         Truth.assertThat(binding.binds(TestAccountFragmentContract())).isFalse()
+    }
+
+    @Test
+    fun `bind flow factory with Any dependency type`() {
+        val store = FragmentFlowStore.init("Component") {
+            // If it compiles, it's a success
+            bind(EmptyFlowFactory<Any>())
+        }
     }
 }


### PR DESCRIPTION
## What
This allows interface-based `Dependency` types instead of concrete ones. Because `String` component is also an `Any` we can request `Any` dependency type.
```kotlin
FragmentFlowStore.build<String> {
  bind(FlowFactory<Any>())
}
```
