### PR TITLE
[Android] Remove early fragment removal logic.

### DIFF
--- a/formula-android-tests/src/main/java/com/instacart/formula/test/TestFragmentActivity.kt
+++ b/formula-android-tests/src/main/java/com/instacart/formula/test/TestFragmentActivity.kt
@@ -26,7 +26,7 @@ class TestFragmentActivity : FormulaAppCompatActivity() {
         }
     }
 
-    fun navigateTo(key: FragmentKey) {
+    fun navigateTo(key: FragmentKey, allowStateLoss: Boolean = false) {
         val entryIndex = supportFragmentManager.backStackEntryCount - 1
         val fragment = if (entryIndex >= 0) {
             val entry = supportFragmentManager.getBackStackEntryAt(entryIndex)
@@ -41,7 +41,13 @@ class TestFragmentActivity : FormulaAppCompatActivity() {
             }
             add(R.id.activity_content, FormulaFragment.newInstance(key), key.tag)
             addToBackStack(key.tag)
-        }.commit()
+        }.apply {
+            if (allowStateLoss) {
+                commitAllowingStateLoss()
+            } else {
+                commit()
+            }
+        }
     }
 
     override fun onBackPressed() {

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -28,6 +28,7 @@ class FragmentFlowRenderViewTest {
 
     private var lastState: FragmentFlowState? = null
     private val stateChangeRelay = PublishRelay.create<Pair<FragmentContract<*>, Any>>()
+    private var onPreCreated: (TestFragmentActivity) -> Unit = {}
     private val formulaRule = TestFormulaRule(
         initFormula = { app ->
             FormulaAndroid.init(app) {
@@ -35,6 +36,7 @@ class FragmentFlowRenderViewTest {
                     store(
                         configureActivity = {
                             initialContract = TestContract()
+                            onPreCreated(this)
                         },
                         onRenderFragmentState = { a, state ->
                             lastState = state
@@ -205,9 +207,9 @@ class FragmentFlowRenderViewTest {
         scenario.onActivity { it.onBackPressed() }
     }
 
-    private fun navigateToTaskDetail(id: Int = 1) {
+    private fun navigateToTaskDetail(id: Int = 1, allowStateLoss: Boolean = false) {
         scenario.onActivity {
-            it.navigateTo(TestContractWithId(id))
+            it.navigateTo(TestContractWithId(id), allowStateLoss = allowStateLoss)
         }
     }
 


### PR DESCRIPTION
## What
This logic might not be needed anymore since we generate a unique identifier for each formula.