### PR TITLE
[Test] Add TestFormulaObserver.input()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@
 - Move `FragmentContract` into `android` package.
 - Move `FragmentFlowState` into `android` package.
 - Move `FragmentFlowStore` into `android` package.
+- **Breaking**: Replaced `formula.test(inputObservable)` with `formula.test().input()` 
+- Add `TestFormulaObserver.assertNoErrors()`
 
 ## [0.6.1] - November 18, 2020
 - Bugfix: Fix runtime ignoring `Formula.key` for the root formula.

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -24,18 +24,21 @@ class TestFormulaObserver<Input : Any, Output : Any, FormulaT : IFormula<Input, 
      */
     fun input(value: Input) = apply {
         started = true
+        assertNoErrors() // Check before interaction
         inputRelay.onNext(value)
-        assertNoErrors()
+        assertNoErrors() // Check after interaction
     }
 
     inline fun output(assert: Output.() -> Unit) = apply {
         ensureFormulaIsRunning()
+        assertNoErrors() // Check before interaction
         assert(values().last())
-        assertNoErrors()
+        assertNoErrors() // Check after interaction
     }
 
     fun assertOutputCount(count: Int) = apply {
         ensureFormulaIsRunning()
+        assertNoErrors()
         val size = values().size
         assert(size == count) {
             "Expected: $count, was: $size"

--- a/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
@@ -2,37 +2,25 @@ package com.instacart.formula.test
 
 import com.instacart.formula.IFormula
 import com.instacart.formula.Stream
-import io.reactivex.rxjava3.core.Observable
 
 /**
  * An extension function to create a [TestFormulaObserver] for a [IFormula] instance.
- *
- * @param input Input passed to [IFormula].
  */
-fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
-    input: Input
-): TestFormulaObserver<Input, Output, F> {
-    return test(Observable.just(input))
-}
-
-
-/**
- * An extension function to create a [TestFormulaObserver] for a [IFormula] instance.
- *
- * @param input A stream of inputs passed to [IFormula].
- */
-fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
-    input: Observable<Input>
-): TestFormulaObserver<Input, Output, F> {
-    return TestFormulaObserver(
-        input = input,
-        formula = this
-    )
+fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(): TestFormulaObserver<Input, Output, F> {
+    return TestFormulaObserver(this)
 }
 
 /**
  * An extension function to create a [TestFormulaObserver] for a [IFormula] instance.
+ *
+ * @param initialInput Input passed to [IFormula].
  */
-fun <Output : Any, F: IFormula<Unit, Output>> F.test() = test(Unit)
+fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
+    initialInput: Input
+): TestFormulaObserver<Input, Output, F> {
+    return test().apply {
+        input(initialInput)
+    }
+}
 
 fun <Message> Stream<Message>.test() = TestStreamObserver(this)

--- a/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
@@ -5,6 +5,8 @@ import com.instacart.formula.Stream
 
 /**
  * An extension function to create a [TestFormulaObserver] for a [IFormula] instance.
+ *
+ * Note: Formula won't start until you pass it an [input][TestFormulaObserver.input].
  */
 fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(): TestFormulaObserver<Input, Output, F> {
     return TestFormulaObserver(this)

--- a/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
@@ -16,7 +16,7 @@ class TestFormulaTest {
     @Before fun setup() {
         childFormula = FakeChildFormula()
         parentFormula = ParentFormula(childFormula)
-        subject = ParentFormula(childFormula = childFormula).test()
+        subject = ParentFormula(childFormula = childFormula).test(Unit)
     }
 
     @Test fun `trigger callback using child input`() {

--- a/formula/src/test/java/com/instacart/formula/ChildRemovedOnMessage.kt
+++ b/formula/src/test/java/com/instacart/formula/ChildRemovedOnMessage.kt
@@ -13,7 +13,7 @@ class ChildRemovedOnMessage {
                 }
             )
         })
-        .test()
+        .test(Unit)
 
     fun assertChildIsVisible(visible: Boolean) = apply {
         subject.output {

--- a/formula/src/test/java/com/instacart/formula/ChildStreamEvents.kt
+++ b/formula/src/test/java/com/instacart/formula/ChildStreamEvents.kt
@@ -6,7 +6,7 @@ import com.instacart.formula.test.test
 class ChildStreamEvents {
 
     private val child = StartStopFormula()
-    private val subject = HasChildFormula(child).test()
+    private val subject = HasChildFormula(child).test(Unit)
 
     fun startListening() = apply {
         subject.output { child.startListening() }

--- a/formula/src/test/java/com/instacart/formula/DuplicateChildrenTest.kt
+++ b/formula/src/test/java/com/instacart/formula/DuplicateChildrenTest.kt
@@ -9,7 +9,7 @@ import kotlin.IllegalStateException
 class DuplicateChildrenTest {
 
     @Test fun `adding duplicate child throws an exception`() {
-        val error = Try { ParentFormula().test() }.errorOrNull()?.cause
+        val error = Try { ParentFormula().test(Unit) }.errorOrNull()?.cause
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
     }
 

--- a/formula/src/test/java/com/instacart/formula/DynamicFormulaInputTest.kt
+++ b/formula/src/test/java/com/instacart/formula/DynamicFormulaInputTest.kt
@@ -2,7 +2,6 @@ package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.test.test
-import io.reactivex.rxjava3.core.Observable
 import org.junit.Test
 
 class DynamicFormulaInputTest {
@@ -10,7 +9,10 @@ class DynamicFormulaInputTest {
     @Test
     fun `using dynamic input`() {
         TestFormula()
-            .test(Observable.just(1, 2, 3))
+            .test()
+            .input(1)
+            .input(2)
+            .input(3)
             .apply {
                 assertThat(values()).containsExactly(1, 2, 3).inOrder()
             }

--- a/formula/src/test/java/com/instacart/formula/DynamicStreamSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/DynamicStreamSubject.kt
@@ -2,14 +2,12 @@ package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.test.test
-import com.jakewharton.rxrelay3.PublishRelay
 
 class DynamicStreamSubject {
-    private val streams = PublishRelay.create<List<String>>()
-    private val subject = TestFormula().test(streams)
+    private val subject = TestFormula().test()
 
     fun updateStreams(vararg keys: String) = apply {
-        streams.accept(keys.asList())
+        subject.input(keys.asList())
         assertRunning(*keys)
     }
 

--- a/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FetchDataExampleTest.kt
@@ -11,7 +11,7 @@ class FetchDataExampleTest {
     @Test fun `fake network example`() {
 
         MyFormula()
-            .test()
+            .test(Unit)
             .apply {
                 values().last().onChangeId("1")
                 values().last().onChangeId("2")

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -17,7 +17,7 @@ class FormulaRuntimeTest {
     @Test
     fun `multiple event updates`() {
         StartStopFormula()
-            .test()
+            .test(Unit)
             .output { startListening() }
             .apply { formula.incrementEvents.triggerIncrement() }
             .apply { formula.incrementEvents.triggerIncrement() }
@@ -31,7 +31,7 @@ class FormulaRuntimeTest {
     @Test
     fun `no state changes after event stream is removed`() {
         StartStopFormula()
-            .test()
+            .test(Unit)
             .output { startListening() }
             .apply { formula.incrementEvents.triggerIncrement() }
             .output { stopListening() }
@@ -47,7 +47,7 @@ class FormulaRuntimeTest {
     fun `each child event handler should be scoped to latest state`() {
         MultipleChildEvents
             .formula()
-            .test()
+            .test(Unit)
             .output { child.incrementAndMessage() }
             .output { child.incrementAndMessage() }
             .output { child.incrementAndMessage() }
@@ -85,7 +85,7 @@ class FormulaRuntimeTest {
         val sideEffectCallback = TestCallback()
         TransitionAfterNoEvaluationPass
             .formula(sideEffectCallback)
-            .test()
+            .test(Unit)
             .output { triggerSideEffect() }
             .output { triggerSideEffect() }
             .assertOutputCount(1)
@@ -99,7 +99,7 @@ class FormulaRuntimeTest {
         val sideEffectCallback = TestCallback()
         ChildTransitionAfterNoEvaluationPass
             .formula(sideEffectCallback)
-            .test()
+            .test(Unit)
             .output { child.triggerSideEffect() }
             .output { child.triggerSideEffect() }
             .assertOutputCount(1)
@@ -114,7 +114,7 @@ class FormulaRuntimeTest {
         val sideEffectCallback = TestCallback()
         NestedChildTransitionAfterNoEvaluationPass
             .formula(sideEffectCallback)
-            .test()
+            .test(Unit)
             .output { child.child.triggerSideEffect() }
             .output { child.child.triggerSideEffect() }
             .assertOutputCount(1)
@@ -152,7 +152,7 @@ class FormulaRuntimeTest {
     fun `child message with no parent state change`() {
         ChildMessageNoParentStateChange
             .formula()
-            .test()
+            .test(Unit)
             .output { child.triggerMessage() }
             .assertOutputCount(1)  // no state change, so no re-evaluation
     }
@@ -161,7 +161,7 @@ class FormulaRuntimeTest {
     fun `child message with parent state change`() {
         ChildMessageWithParentStateChange
             .formula()
-            .test()
+            .test(Unit)
             .output { child.triggerMessage() }
             .assertOutputCount(2)
             .output { assertThat(state).isEqualTo(1) }
@@ -171,7 +171,7 @@ class FormulaRuntimeTest {
     fun `side effect triggers parent state transition`() {
         ChildMessageTriggersEventTransitionInParent
             .formula()
-            .test()
+            .test(Unit)
             .output { child.triggerSideEffect() }
             .output {
                 assertThat(count).isEqualTo(1)
@@ -182,7 +182,7 @@ class FormulaRuntimeTest {
     fun `child state is reset after toggle`() {
         ChildStateResetAfterToggle
             .formula()
-            .test()
+            .test(Unit)
             .output { child!!.incrementAndMessage() }
             .output { child!!.incrementAndMessage() }
             .output { assertThat(child!!.state).isEqualTo(2) }
@@ -208,7 +208,7 @@ class FormulaRuntimeTest {
 
     @Test
     fun `multiple event callbacks using the same render model`() {
-        EventCallbackFormula().test()
+        EventCallbackFormula().test(Unit)
             .output {
                 changeState("one")
                 changeState("two")
@@ -222,7 +222,7 @@ class FormulaRuntimeTest {
         OptionalChildFormula(MessageFormula()) {
             MessageFormula.Input(messageHandler = eventCallback { none() })
         }
-            .test()
+            .test(Unit)
             .output {
                 val cachedChild = child!!
                 toggleChild()
@@ -248,7 +248,7 @@ class FormulaRuntimeTest {
 
     @Test
     fun `event callbacks are equal across render model changes`() {
-        EventCallbackFormula().test()
+        EventCallbackFormula().test(Unit)
             .output {
                 changeState("one")
                 changeState("two")
@@ -262,7 +262,7 @@ class FormulaRuntimeTest {
     @Test
     fun `removed callback is disabled`() {
         OptionalCallbackFormula()
-            .test()
+            .test(Unit)
             .output {
 
                 callback?.invoke()
@@ -277,7 +277,7 @@ class FormulaRuntimeTest {
     @Test
     fun `callbacks are not the same after removing then adding it again`() {
         OptionalCallbackFormula()
-            .test()
+            .test(Unit)
             .output {
                 toggleCallback()
                 toggleCallback()
@@ -290,7 +290,7 @@ class FormulaRuntimeTest {
     @Test
     fun `removed event callback is disabled`() {
         OptionalEventCallbackFormula()
-            .test()
+            .test(Unit)
             .output {
                 callback?.invoke(1)
                 toggleCallback()
@@ -304,7 +304,7 @@ class FormulaRuntimeTest {
     @Test
     fun `event callbacks are not the same after removing then adding it again`() {
         OptionalEventCallbackFormula()
-            .test()
+            .test(Unit)
             .output {
                 toggleCallback()
                 toggleCallback()
@@ -323,7 +323,7 @@ class FormulaRuntimeTest {
     @Test
     fun `using key to scope callbacks within another function`() {
         UsingKeyToScopeCallbacksWithinAnotherFunction.TestFormula()
-            .test()
+            .test(Unit)
             .assertOutputCount(1)
     }
 
@@ -357,7 +357,10 @@ class FormulaRuntimeTest {
     @Test
     fun `input changed message`() {
         StreamInputFormula()
-            .test(input = Observable.range(0, 3))
+            .test()
+            .input(0)
+            .input(1)
+            .input(2)
             .apply {
                 assertThat(formula.messages).containsExactly(0, 1, 2).inOrder()
             }
@@ -366,7 +369,11 @@ class FormulaRuntimeTest {
     @Test
     fun `events api ignores duplicate inputs`() {
         StreamInputFormula()
-            .test(input = Observable.just(0, 0, 0, 0))
+            .test()
+            .input(0)
+            .input(0)
+            .input(0)
+            .input(0)
             .apply {
                 assertThat(formula.messages).containsExactly(0).inOrder()
             }
@@ -399,7 +406,7 @@ class FormulaRuntimeTest {
         }
 
         formula
-            .test()
+            .test(Unit)
             .assertOutputCount(1)
     }
 
@@ -416,7 +423,7 @@ class FormulaRuntimeTest {
         }
 
         formula
-            .test()
+            .test(Unit)
             .assertOutputCount(1)
     }
 
@@ -431,7 +438,7 @@ class FormulaRuntimeTest {
             }
         }
 
-        val error = Try { formula.test() }.errorOrNull()?.cause
+        val error = Try { formula.test(Unit) }.errorOrNull()?.cause
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
     }
 
@@ -446,7 +453,7 @@ class FormulaRuntimeTest {
             }
         }
 
-        formula.test().assertOutputCount(1)
+        formula.test(Unit).assertOutputCount(1)
     }
 
     @Test
@@ -466,7 +473,7 @@ class FormulaRuntimeTest {
             }
         }
 
-        formula.test().apply {
+        formula.test(Unit).apply {
             assertThat(executed).isEqualTo(2)
         }
     }
@@ -500,14 +507,14 @@ class FormulaRuntimeTest {
             }
         }
 
-        val error = Try { formula.test() }.errorOrNull()?.cause
+        val error = Try { formula.test(Unit) }.errorOrNull()?.cause
         assertThat(error).isInstanceOf(IllegalStateException::class.java)
     }
 
     @Test
     fun `disposing formula triggers terminate message`() {
         TerminateFormula()
-            .test()
+            .test(Unit)
             .apply {
                 assertThat(formula.timesTerminateCalled).isEqualTo(0)
             }
@@ -521,7 +528,7 @@ class FormulaRuntimeTest {
     fun `removing child formula triggers terminate message`() {
         val terminateFormula = TerminateFormula()
         OptionalChildFormula(terminateFormula)
-            .test()
+            .test(Unit)
             .apply {
                 assertThat(terminateFormula.timesTerminateCalled).isEqualTo(0)
             }
@@ -545,7 +552,10 @@ class FormulaRuntimeTest {
         }
 
         formula
-            .test(Observable.just(1, 2, 3))
+            .test()
+            .input(1)
+            .input(2)
+            .input(3)
             .dispose()
             .apply {
                 assertThat(emissions).isEqualTo(1)
@@ -558,7 +568,7 @@ class FormulaRuntimeTest {
         val terminateFormula = TerminateFormula()
         val formula = OptionalChildFormula(HasChildFormula(terminateFormula))
 
-        formula.test().output { toggleChild() }.apply {
+        formula.test(Unit).output { toggleChild() }.apply {
             assertThat(terminateFormula.timesTerminateCalled).isEqualTo(1)
         }
     }
@@ -574,13 +584,15 @@ class FormulaRuntimeTest {
                 return Evaluation(Unit)
             }
         }
-        formula.test().dispose()
+        formula.test(Unit).dispose()
         assertThat(terminateFormula.timesTerminateCalled).isEqualTo(10)
     }
 
     @Test fun `nested termination with input changed`() {
-        NestedTerminationWithInputChanged()
-            .test(Observable.just(false, true, false))
+        NestedTerminationWithInputChanged().test()
+            .input(false)
+            .input(true)
+            .input(false)
             .apply {
                 assertThat(formula.terminateFormula.timesTerminateCalled).isEqualTo(1)
             }
@@ -589,13 +601,9 @@ class FormulaRuntimeTest {
     @Test
     fun `canceling terminate stream does not emit terminate message`() {
         val terminateCallback = TestCallback()
-        RemovingTerminateStreamSendsNoMessagesFormula()
-            .test(
-                input = Observable.just(
-                    RemovingTerminateStreamSendsNoMessagesFormula.Input(onTerminate = terminateCallback),
-                    RemovingTerminateStreamSendsNoMessagesFormula.Input(onTerminate = null)
-                )
-            )
+        RemovingTerminateStreamSendsNoMessagesFormula().test()
+            .input(RemovingTerminateStreamSendsNoMessagesFormula.Input(onTerminate = terminateCallback))
+            .input(RemovingTerminateStreamSendsNoMessagesFormula.Input(onTerminate = null))
             .apply {
                 terminateCallback.assertTimesCalled(0)
             }
@@ -604,12 +612,9 @@ class FormulaRuntimeTest {
     @Test
     fun `using from observable with input`() {
         val onItem = TestEventCallback<FromObservableWithInputFormula.Item>()
-        FromObservableWithInputFormula()
-            .test(
-                input = Observable.just("1", "2").map {
-                    FromObservableWithInputFormula.Input(it, onItem = onItem)
-                }
-            )
+        FromObservableWithInputFormula().test()
+            .input(FromObservableWithInputFormula.Input("1", onItem = onItem))
+            .input(FromObservableWithInputFormula.Input("2", onItem = onItem))
             .apply {
                 assertThat(onItem.values()).containsExactly(
                     FromObservableWithInputFormula.Item("1"),
@@ -626,14 +631,14 @@ class FormulaRuntimeTest {
 
     @Test
     fun `initialize 100 levels nested formula`() {
-        ExtremelyNestedFormula.nested(100).test().output {
+        ExtremelyNestedFormula.nested(100).test(Unit).output {
             assertThat(this).isEqualTo(100)
         }
     }
 
     @Test
     fun `initialize 250 levels nested formula`() {
-        ExtremelyNestedFormula.nested(250).test().output {
+        ExtremelyNestedFormula.nested(250).test(Unit).output {
             assertThat(this).isEqualTo(250)
         }
     }
@@ -641,7 +646,7 @@ class FormulaRuntimeTest {
     @Ignore("stack overflows when there are 500 nested child formulas")
     @Test
     fun `initialize 500 levels nested formula`() {
-        ExtremelyNestedFormula.nested(500).test().output {
+        ExtremelyNestedFormula.nested(500).test(Unit).output {
             assertThat(this).isEqualTo(500)
         }
     }
@@ -649,14 +654,14 @@ class FormulaRuntimeTest {
     @Test
     fun `mixing callback use with key use`() {
         MixingCallbackUseWithKeyUse.ParentFormula()
-            .test()
+            .test(Unit)
             .assertOutputCount(1)
     }
 
     // TODO: maybe worth adding support eventually.
     @Test
     fun `nested keys are not allowed`() {
-        val error = Try { NestedKeyFormula().test() }.errorOrNull()?.cause
+        val error = Try { NestedKeyFormula().test(Unit) }.errorOrNull()?.cause
         assertThat(error)
             .apply { isInstanceOf(IllegalStateException::class.java)  }
             .hasMessageThat().startsWith("Nested scopes are not supported currently.")

--- a/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
+++ b/formula/src/test/java/com/instacart/formula/InputChangedTest.kt
@@ -7,7 +7,7 @@ import org.junit.Test
 class InputChangedTest {
 
     @Test fun `input changes`() {
-        ParentFormula().test()
+        ParentFormula().test(Unit)
             .output { onChildNameChanged("first") }
             .output { onChildNameChanged("second") }
             .apply {

--- a/formula/src/test/java/com/instacart/formula/ManyEmissionStreamTest.kt
+++ b/formula/src/test/java/com/instacart/formula/ManyEmissionStreamTest.kt
@@ -13,7 +13,7 @@ class ManyEmissionStreamTest {
 
     @Test fun `all increment events go through`() {
         TestFormula()
-            .test()
+            .test(Unit)
             .apply {
                 assertThat(values()).containsExactly(EMISSION_COUNT).inOrder()
             }

--- a/formula/src/test/java/com/instacart/formula/ObservableFormulaTest.kt
+++ b/formula/src/test/java/com/instacart/formula/ObservableFormulaTest.kt
@@ -3,7 +3,6 @@ package com.instacart.formula
 import com.google.common.truth.Truth
 import com.instacart.formula.rxjava3.ObservableFormula
 import com.instacart.formula.test.test
-import com.jakewharton.rxrelay3.BehaviorRelay
 import com.jakewharton.rxrelay3.PublishRelay
 import io.reactivex.rxjava3.core.Observable
 import org.junit.Test
@@ -35,12 +34,11 @@ class ObservableFormulaTest {
 
     @Test
     fun `new input restarts formula`() {
-        val inputRelay = PublishRelay.create<String>()
         SubjectFormula()
-            .test(inputRelay)
-            .apply { inputRelay.accept("initial") }
+            .test()
+            .input("initial")
             .apply { formula.relay.accept(1) }
-            .apply { inputRelay.accept("reset") }
+            .input("reset")
             .apply { formula.relay.accept(1) }
             .apply {
                 Truth.assertThat(values()).containsExactly(0, 1, 0, 1).inOrder()

--- a/formula/src/test/java/com/instacart/formula/RootFormulaKeyTestSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/RootFormulaKeyTestSubject.kt
@@ -2,12 +2,11 @@ package com.instacart.formula
 
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.test.test
-import com.jakewharton.rxrelay3.BehaviorRelay
 
 class RootFormulaKeyTestSubject {
 
-    private val inputRelay = BehaviorRelay.createDefault(0)
-    private val subject = MyFormula.test(inputRelay)
+    private var input: Int = 0
+    private val subject = MyFormula.test(input)
 
     fun increment() = apply {
         subject.output { increment() }
@@ -20,7 +19,8 @@ class RootFormulaKeyTestSubject {
     }
 
     fun resetKey() = apply {
-        inputRelay.accept(inputRelay.value + 1)
+        input += 1
+        subject.input(input)
     }
 
 

--- a/formula/src/test/java/com/instacart/formula/SimpleSideEffectTest.kt
+++ b/formula/src/test/java/com/instacart/formula/SimpleSideEffectTest.kt
@@ -14,7 +14,7 @@ class SimpleSideEffectTest {
         TestFormula(
             increment = Observable.fromIterable(intRange.map { Unit }),
             onGameOver = gameOverCallback
-        ).test()
+        ).test(Unit)
 
         gameOverCallback.assertTimesCalled(1)
     }

--- a/formula/src/test/java/com/instacart/formula/StreamInitMessageDeliveredOnce.kt
+++ b/formula/src/test/java/com/instacart/formula/StreamInitMessageDeliveredOnce.kt
@@ -3,7 +3,7 @@ package com.instacart.formula
 import com.instacart.formula.test.test
 
 object StreamInitMessageDeliveredOnce {
-    fun test() = TestFormula().test()
+    fun test() = TestFormula().test(Unit)
 
     class TestFormula : StatelessFormula<Unit, Unit>() {
         var timesInitializedCalled = 0

--- a/formula/src/test/java/com/instacart/formula/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
+++ b/formula/src/test/java/com/instacart/formula/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
@@ -6,7 +6,7 @@ import io.reactivex.rxjava3.core.Observable
 
 object SubscribesToAllUpdatesBeforeDeliveringMessages {
 
-    fun test() = TestFormula().test()
+    fun test() = TestFormula().test(Unit)
 
     class TestFormula : Formula<Unit, Int, Int> {
         private val initial = RxStream.fromObservable { Observable.just(Unit, Unit, Unit, Unit) }

--- a/formula/src/test/java/com/instacart/formula/UsingCallbacksWithinAnotherFunction.kt
+++ b/formula/src/test/java/com/instacart/formula/UsingCallbacksWithinAnotherFunction.kt
@@ -4,7 +4,7 @@ import com.instacart.formula.test.test
 
 object UsingCallbacksWithinAnotherFunction {
 
-    fun test() = TestFormula().test()
+    fun test() = TestFormula().test(Unit)
 
     class TestOutput(
         val first: () -> Unit,

--- a/formula/src/test/java/com/instacart/formula/tests/EmitErrorTest.kt
+++ b/formula/src/test/java/com/instacart/formula/tests/EmitErrorTest.kt
@@ -8,7 +8,7 @@ import com.instacart.formula.test.test
 import java.lang.IllegalStateException
 
 object EmitErrorTest {
-    fun test() = MyFormula().test()
+    fun test() = MyFormula().test(Unit)
 
     class MyFormula : StatelessFormula<Unit, Unit>() {
         override fun evaluate(input: Unit, context: FormulaContext<Unit>): Evaluation<Unit> {

--- a/formula/src/test/java/com/instacart/formula/tests/NullableStateTest.kt
+++ b/formula/src/test/java/com/instacart/formula/tests/NullableStateTest.kt
@@ -11,7 +11,7 @@ class NullableStateTest {
 
     @Test fun `nullable state changes`() {
         TestFormula()
-            .test()
+            .test(Unit)
             .output { Truth.assertThat(state).isNull() }
             .output { updateState("new state") }
             .output { Truth.assertThat(state).isEqualTo("new state") }

--- a/samples/counter/src/test/java/com/instacart/formula/counter/CounterFormulaTest.kt
+++ b/samples/counter/src/test/java/com/instacart/formula/counter/CounterFormulaTest.kt
@@ -9,7 +9,7 @@ class CounterFormulaTest {
     @Test fun `increment 5 times`() {
 
         CounterFormula()
-            .test()
+            .test(Unit)
             .output { onIncrement() }
             .output { onIncrement() }
             .output { onIncrement() }

--- a/samples/stopwatch/src/test/java/com/instacart/formula/stopwatch/StopwatchFormulaTest.kt
+++ b/samples/stopwatch/src/test/java/com/instacart/formula/stopwatch/StopwatchFormulaTest.kt
@@ -7,8 +7,6 @@ class StopwatchFormulaTest {
 
     // TODO:
     @Test fun `increment 5 times`() {
-
-        StopwatchFormula()
-            .test(Unit)
+        StopwatchFormula().test(Unit)
     }
 }


### PR DESCRIPTION
## What
To simplify passing multiple inputs, adding `TestFormulaObserver.input` function. Also, adding more `assertNoErrors` checks.