### PR TITLE
Specify java version 11 for jitpack.

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,1 @@
+jdk: openjdk11


### PR DESCRIPTION
## What
Seeing issue when Jitpack tries to build latest version
```
Build file '/home/jitpack/build/formula-android/build.gradle' line: 1

* What went wrong:
A problem occurred evaluating project ':formula-android'.
> Failed to apply plugin 'com.android.internal.library'.
   > Android Gradle plugin requires Java 11 to run. You are currently using Java 1.8.
     You can try some of the following options:
       - changing the IDE settings.
       - changing the JAVA_HOME environment variable.
       - changing `org.gradle.java.home` in `gradle.properties`.
```