### PR TITLE
Rename Update to BoundStream.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/BoundStream.kt
+++ b/formula/src/main/java/com/instacart/formula/BoundStream.kt
@@ -1,6 +1,6 @@
 package com.instacart.formula
 
-class Update<Message>(
+class BoundStream<Message>(
     val key: Any,
     val stream: Stream<Message>,
     initial: (Message) -> Unit
@@ -24,7 +24,7 @@ class Update<Message>(
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as Update<*>
+        other as BoundStream<*>
 
         if (key != other.key) return false
 

--- a/formula/src/main/java/com/instacart/formula/Evaluation.kt
+++ b/formula/src/main/java/com/instacart/formula/Evaluation.kt
@@ -10,5 +10,5 @@ package com.instacart.formula
  */
 data class Evaluation<out Output>(
     val output: Output,
-    val updates: List<Update<*>> = emptyList()
+    val updates: List<BoundStream<*>> = emptyList()
 )

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
@@ -3,7 +3,7 @@ package com.instacart.formula.internal
 import com.instacart.formula.FormulaContext
 import com.instacart.formula.IFormula
 import com.instacart.formula.Transition
-import com.instacart.formula.Update
+import com.instacart.formula.BoundStream
 import java.lang.IllegalStateException
 
 class FormulaContextImpl<State> internal constructor(
@@ -25,7 +25,7 @@ class FormulaContextImpl<State> internal constructor(
         transitionCallback.invoke(transition)
     }
 
-    override fun updates(init: UpdateBuilder<State>.() -> Unit): List<Update<*>> {
+    override fun updates(init: UpdateBuilder<State>.() -> Unit): List<BoundStream<*>> {
         ensureNotRunning()
         val builder = UpdateBuilder(transitionCallback)
         builder.init()

--- a/formula/src/main/java/com/instacart/formula/internal/UpdateManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/UpdateManager.kt
@@ -1,23 +1,23 @@
 package com.instacart.formula.internal
 
-import com.instacart.formula.Update
+import com.instacart.formula.BoundStream
 
 /**
- * Handles [Update] changes.
+ * Handles [BoundStream] changes.
  */
 internal class UpdateManager {
     companion object {
         val NO_OP: (Any?) -> Unit = {}
     }
 
-    private var running: LinkedHashSet<Update<*>>? = null
+    private var running: LinkedHashSet<BoundStream<*>>? = null
 
     /**
      * Ensures that all updates will point to the correct listener. Also, disables listeners for
      * terminated streams.
      */
     @Suppress("UNCHECKED_CAST")
-    fun updateEventListeners(new: List<Update<*>>) {
+    fun updateEventListeners(new: List<BoundStream<*>>) {
         running?.forEach { existing ->
             val update = new.firstOrNull { it == existing }
             if (update != null) {
@@ -31,7 +31,7 @@ internal class UpdateManager {
     /**
      * Returns true if there was a transition while terminating streams.
      */
-    fun terminateOld(requested: List<Update<*>>, transitionId: TransitionId): Boolean {
+    fun terminateOld(requested: List<BoundStream<*>>, transitionId: TransitionId): Boolean {
         val iterator = running?.iterator() ?: return false
         while (iterator.hasNext()) {
             val running = iterator.next()
@@ -48,7 +48,7 @@ internal class UpdateManager {
         return false
     }
 
-    fun startNew(requested: List<Update<*>>, transitionId: TransitionId): Boolean {
+    fun startNew(requested: List<BoundStream<*>>, transitionId: TransitionId): Boolean {
         for (update in requested) {
             val running = getOrInitRunningStreamList()
             if (!isRunning(update)) {
@@ -72,22 +72,22 @@ internal class UpdateManager {
         }
     }
 
-    private fun shouldKeepRunning(updates: List<Update<*>>, update: Update<*>): Boolean {
+    private fun shouldKeepRunning(updates: List<BoundStream<*>>, update: BoundStream<*>): Boolean {
         return updates.contains(update)
     }
 
-    private fun isRunning(update: Update<*>): Boolean {
+    private fun isRunning(update: BoundStream<*>): Boolean {
         return running?.contains(update) ?: false
     }
 
-    private fun tearDownStream(stream: Update<*>) {
+    private fun tearDownStream(stream: BoundStream<*>) {
         stream.tearDown()
         stream.handler = NO_OP
     }
 
-    private fun getOrInitRunningStreamList(): LinkedHashSet<Update<*>> {
+    private fun getOrInitRunningStreamList(): LinkedHashSet<BoundStream<*>> {
         return running ?: run {
-            val initialized: LinkedHashSet<Update<*>> = LinkedHashSet()
+            val initialized: LinkedHashSet<BoundStream<*>> = LinkedHashSet()
             this.running = initialized
             initialized
         }


### PR DESCRIPTION
## What
Renaming `Update` to `BoundStream`. There are thoughts about renaming it to `BoundAction` but for time being as #229 is not finalized, I want to get rid of `Update` type here and keep it more closely associated with `Stream` object.
