### PR TITLE
Consolidating Transition type.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -12,7 +12,7 @@ import com.instacart.formula.internal.UnitCallback
  */
 abstract class FormulaContext<State> internal constructor(
     @PublishedApi internal val callbacks: ScopedCallbacks<State>,
-    private val transitionDispatcher: TransitionDispatcher<State>,
+    internal val transitionDispatcher: TransitionDispatcher<State>,
 ) {
 
     /**
@@ -128,7 +128,7 @@ abstract class FormulaContext<State> internal constructor(
      * Provides methods to declare various events and effects.
      */
     class UpdateBuilder<State> internal constructor(
-        private val transitionDispatcher: TransitionDispatcher<State>
+        private val formulaContext: FormulaContext<State>,
     ) {
         internal val updates = mutableListOf<BoundStream<*>>()
 
@@ -191,9 +191,10 @@ abstract class FormulaContext<State> internal constructor(
             stream: Stream<Message>,
             transition: Update<State, Message>,
         ): BoundStream<Message> {
-            val callback = transitionDispatcher.toCallback(transition)
+            val key = JoinedKey(stream.key(), transition::class)
+            val callback = formulaContext.onEvent(key, transition)
             return BoundStream(
-                key = JoinedKey(stream.key(), transition::class),
+                key = key,
                 stream = stream,
                 initial = callback
             )

--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -15,55 +15,28 @@ abstract class FormulaContext<State> internal constructor(
 ) {
 
     /**
-     * Creates a callback to be used for handling UI event transitions.
+     * Creates a callback that takes a [Event] and performs a [Transition].
      *
      * It uses inlined callback anonymous class for type.
      */
-    fun onEvent(transition: UpdateType<State, Unit>): () -> Unit {
-        val callback = transitionDispatcher.toCallback(transition)
-        val reference = callbacks.initOrFindCallback(transition::class)
-        reference.delegate = callback
+    fun <Event> onEvent(
+        transition: UpdateType<State, Event>,
+    ): Listener<Event> {
+        val reference = callbacks.initOrFindEventCallback<Event>(transition::class)
+        reference.delegate = transitionDispatcher.toCallback(transition)
         return reference
     }
 
     /**
-     * Creates a callback to be used for handling UI event transitions.
+     * Creates a callback that takes a [Event] and performs a [Transition].
      *
      * @param key key with which the callback is to be associated. Same key cannot be used for multiple callbacks.
      */
-    fun onEvent(
+    fun <Event> onEvent(
         key: Any,
-        transition: UpdateType<State, Unit>,
-    ): () -> Unit {
-        val callback = callbacks.initOrFindCallback(key)
-        callback.delegate = transitionDispatcher.toCallback(transition)
-        return callback
-    }
-
-    /**
-     * Creates a callback that takes a [UIEvent] and performs a [Transition].
-     *
-     * It uses inlined callback anonymous class for type.
-     */
-    fun <UIEvent> onEvent(
-        transition: UpdateType<State, UIEvent>,
-    ): (UIEvent) -> Unit {
-        val callback = transitionDispatcher.toCallback(transition)
-        val reference = callbacks.initOrFindEventCallback<UIEvent>(transition::class)
-        reference.delegate = callback
-        return reference
-    }
-
-    /**
-     * Creates a callback that takes a [UIEvent] and performs a [Transition].
-     *
-     * @param key key with which the callback is to be associated. Same key cannot be used for multiple callbacks.
-     */
-    fun <UIEvent> onEvent(
-        key: Any,
-        transition: UpdateType<State, UIEvent>,
-    ): (UIEvent) -> Unit {
-        val callback = callbacks.initOrFindEventCallback<UIEvent>(key)
+        transition: UpdateType<State, Event>,
+    ): Listener<Event> {
+        val callback = callbacks.initOrFindEventCallback<Event>(key)
         callback.delegate = transitionDispatcher.toCallback(transition)
         return callback
     }
@@ -74,7 +47,9 @@ abstract class FormulaContext<State> internal constructor(
      * It uses inlined callback anonymous class for type.
      */
     fun callback(transition: UpdateType<State, Unit>): () -> Unit {
-        return onEvent(transition)
+        val reference = callbacks.initOrFindCallback(transition::class)
+        reference.delegate = transitionDispatcher.toCallback(transition)
+        return reference
     }
 
     /**
@@ -86,29 +61,31 @@ abstract class FormulaContext<State> internal constructor(
         key: Any,
         transition: UpdateType<State, Unit>
     ): () -> Unit {
-        return onEvent(key, transition)
+        val callback = callbacks.initOrFindCallback(key)
+        callback.delegate = transitionDispatcher.toCallback(transition)
+        return callback
     }
 
     /**
-     * Creates a callback that takes a [UIEvent] and performs a [Transition].
+     * Creates a callback that takes a [Event] and performs a [Transition].
      *
      * It uses inlined callback anonymous class for type.
      */
-    fun <UIEvent> eventCallback(
-        transition: UpdateType<State, UIEvent>,
-    ): (UIEvent) -> Unit {
+    fun <Event> eventCallback(
+        transition: UpdateType<State, Event>,
+    ): Listener<Event> {
         return onEvent(transition)
     }
 
     /**
-     * Creates a callback that takes a [UIEvent] and performs a [Transition].
+     * Creates a callback that takes a [Event] and performs a [Transition].
      *
      * @param key key with which the callback is to be associated. Same key cannot be used for multiple callbacks.
      */
-    fun <UIEvent> eventCallback(
+    fun <Event> eventCallback(
         key: Any,
-        transition: UpdateType<State, UIEvent>,
-    ): (UIEvent) -> Unit {
+        transition: UpdateType<State, Event>,
+    ): (Event) -> Unit {
         return onEvent(key, transition)
     }
 

--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -35,7 +35,7 @@ abstract class FormulaContext<State> internal constructor(
         key: Any,
         transition: Update<State, Event>,
     ): Listener<Event> {
-        val callback = callbacks.initOrFindEventCallback<Event>(key)
+        val callback = callbacks.initOrFindCallback<Event>(key)
         callback.transitionDispatcher = transitionDispatcher
         callback.transition = transition
         return callback

--- a/formula/src/main/java/com/instacart/formula/Listener.kt
+++ b/formula/src/main/java/com/instacart/formula/Listener.kt
@@ -1,0 +1,13 @@
+package com.instacart.formula
+
+/**
+ * Formula uses Listener callbacks to pass events.
+ */
+fun interface Listener<Event> : (Event) -> Unit {
+
+}
+
+/**
+ * Utility function used to specific
+ */
+operator fun Listener<Unit>.invoke() = invoke(Unit)

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -14,7 +14,7 @@ sealed class Transition<out State> {
          * }
          * ```
          */
-        inline fun <State> create(init: Factory.() -> Transition<State>): Transition<State> {
+        inline fun <State> create(init: TransitionContext.() -> Transition<State>): Transition<State> {
             return init(Factory)
         }
     }
@@ -46,34 +46,7 @@ sealed class Transition<out State> {
     /**
      * Factory uses as a receiver parameter to provide transition constructor dsl.
      */
-    object Factory {
-
-        /**
-         * A transition that does nothing.
-         */
-        fun none(): Transition<Nothing> {
-            return None
-        }
-
-        /**
-         * Creates a transition to a new [State] and executes [invokeEffects] callback
-         * after the state change.
-         */
-        fun <State> transition(
-            state: State,
-            invokeEffects: (() -> Unit)? = null
-        ): Stateful<State> {
-            return Stateful(state, invokeEffects)
-        }
-
-        /**
-         * Creates a transition that only executes [invokeEffects].
-         */
-        fun transition(
-            invokeEffects: () -> Unit
-        ): OnlyEffects {
-            return OnlyEffects(invokeEffects)
-        }
+    object Factory : TransitionContext {
     }
 
     abstract val effects: Effects?

--- a/formula/src/main/java/com/instacart/formula/TransitionContext.kt
+++ b/formula/src/main/java/com/instacart/formula/TransitionContext.kt
@@ -1,0 +1,30 @@
+package com.instacart.formula
+
+interface TransitionContext {
+    /**
+     * A transition that does nothing.
+     */
+    fun none(): Transition<Nothing> {
+        return Transition.None
+    }
+
+    /**
+     * Creates a transition to a new [State] and executes [invokeEffects] callback
+     * after the state change.
+     */
+    fun <State> transition(
+        state: State,
+        invokeEffects: (() -> Unit)? = null
+    ): Transition.Stateful<State> {
+        return Transition.Stateful(state, invokeEffects)
+    }
+
+    /**
+     * Creates a transition that only executes [invokeEffects].
+     */
+    fun transition(
+        invokeEffects: () -> Unit
+    ): Transition.OnlyEffects {
+        return Transition.OnlyEffects(invokeEffects)
+    }
+}

--- a/formula/src/main/java/com/instacart/formula/Update.kt
+++ b/formula/src/main/java/com/instacart/formula/Update.kt
@@ -20,7 +20,7 @@ package com.instacart.formula
  * Issues:
  * - Typealiases are not good for inheritance.
  */
-fun interface UpdateType<State, Event> {
+fun interface Update<State, Event> {
     fun TransitionContext.create(event: Event): Transition<State>
 }
 

--- a/formula/src/main/java/com/instacart/formula/Update.kt
+++ b/formula/src/main/java/com/instacart/formula/Update.kt
@@ -1,24 +1,10 @@
 package com.instacart.formula
 
 /**
- *
- * TODO: document / find a better name.
- *
- * Maybe `Dispatcher`?
- *
- * Naming?
- * - State
- * - Update
- * - Transition
- * - Action
- * - Event
- * - Action -> Event -> Transition/Update ->
- *
- * What am I doing here?
- * - I want to clearly capture the meaning of event handling.
- *
- * Issues:
- * - Typealiases are not good for inheritance.
+ * An update function takes an [Event] and calculates the [Transition] that should happen. A
+ * transition can contain a new [state][State] object which would trigger a [Formula.evaluate]
+ * and/or [Effects] that should be performed. You can return [Transition.None] if nothing
+ * should happen.
  */
 fun interface Update<State, Event> {
     fun TransitionContext.create(event: Event): Transition<State>

--- a/formula/src/main/java/com/instacart/formula/UpdateType.kt
+++ b/formula/src/main/java/com/instacart/formula/UpdateType.kt
@@ -1,0 +1,36 @@
+package com.instacart.formula
+
+/**
+ *
+ * TODO: document / find a better name.
+ *
+ * Maybe `Dispatcher`?
+ *
+ * Naming?
+ * - State
+ * - Update
+ * - Transition
+ * - Action
+ * - Event
+ * - Action -> Event -> Transition/Update ->
+ *
+ * What am I doing here?
+ * - I want to clearly capture the meaning of event handling.
+ *
+ * Issues:
+ * - Typealiases are not good for inheritance.
+ */
+fun interface UpdateType<State, Event> {
+    fun TransitionContext.create(event: Event): Transition<State>
+}
+
+/*
+ * UpdateName
+ */
+class UpdateNameV2 : UpdateType<String, String> {
+    override fun TransitionContext.create(event: String): Transition<String> {
+        return transition(state = event)
+    }
+}
+
+

--- a/formula/src/main/java/com/instacart/formula/UpdateType.kt
+++ b/formula/src/main/java/com/instacart/formula/UpdateType.kt
@@ -24,13 +24,4 @@ fun interface UpdateType<State, Event> {
     fun TransitionContext.create(event: Event): Transition<State>
 }
 
-/*
- * UpdateName
- */
-class UpdateNameV2 : UpdateType<String, String> {
-    override fun TransitionContext.create(event: String): Transition<String> {
-        return transition(state = event)
-    }
-}
-
 

--- a/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
@@ -1,7 +1,7 @@
 package com.instacart.formula.internal
 
 import com.instacart.formula.Listener
-import com.instacart.formula.UpdateType
+import com.instacart.formula.Update
 
 /**
  * Note: this class is not a data class because equality is based on instance and not [key].
@@ -10,7 +10,7 @@ import com.instacart.formula.UpdateType
 internal class CallbackImpl<State, Event>(internal var key: Any) : Listener<Event> {
 
     internal var transitionDispatcher: TransitionDispatcher<State>? = null
-    internal var transition: UpdateType<State, Event>? = null
+    internal var transition: Update<State, Event>? = null
 
     override fun invoke(event: Event) {
         transitionDispatcher?.let { dispatcher ->

--- a/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.internal
 
 import com.instacart.formula.Listener
 import com.instacart.formula.Update
+import java.lang.IllegalStateException
 
 /**
  * Note: this class is not a data class because equality is based on instance and not [key].
@@ -16,6 +17,7 @@ internal class CallbackImpl<State, Event>(internal var key: Any) : Listener<Even
         transitionDispatcher?.let { dispatcher ->
             transition?.let { transition ->
                 dispatcher.dispatch(transition, event)
+                return
             }
         }
         // TODO: log if null callback (it might be due to formula removal or due to callback removal)

--- a/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/CallbackImpl.kt
@@ -1,10 +1,12 @@
 package com.instacart.formula.internal
 
+import com.instacart.formula.Listener
+
 /**
  * Note: this class is not a data class because equality is based on instance and not [key].
  */
 @PublishedApi
-internal open class Callback<T>(internal var key: Any) : (T) -> Unit {
+internal open class CallbackImpl<T>(internal var key: Any) : Listener<T> {
     @PublishedApi internal var delegate: ((T) -> Unit)? = null
 
     override fun invoke(p1: T) {
@@ -17,6 +19,6 @@ internal open class Callback<T>(internal var key: Any) : (T) -> Unit {
  * Note: this class is not a data class because equality is based on instance and not [key].
  */
 @PublishedApi
-internal class UnitCallback(key: Any): Callback<Unit>(key), () -> Unit {
+internal class UnitCallbackImpl(key: Any): CallbackImpl<Unit>(key), () -> Unit {
     override fun invoke() = invoke(Unit)
 }

--- a/formula/src/main/java/com/instacart/formula/internal/Callbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/Callbacks.kt
@@ -1,7 +1,7 @@
 package com.instacart.formula.internal
 
 internal class Callbacks {
-    private var callbacks: SingleRequestMap<Any, Callback<*>>? = null
+    private var callbacks: SingleRequestMap<Any, CallbackImpl<*>>? = null
 
     private fun duplicateKeyErrorMessage(key: Any): String {
         if (key is String) {
@@ -12,32 +12,32 @@ internal class Callbacks {
         return "Callback $key is already defined. Are you calling it in a loop or reusing a method? You can wrap the call with FormulaContext.key"
     }
 
-    fun initOrFindCallbackT(key: Any): UnitCallback {
+    fun initOrFindCallbackT(key: Any): UnitCallbackImpl {
         val callbacks = callbacks ?: run {
-            val initialized: SingleRequestMap<Any, Callback<*>> = mutableMapOf()
+            val initialized: SingleRequestMap<Any, CallbackImpl<*>> = mutableMapOf()
             this.callbacks = initialized
             initialized
         }
 
         return callbacks
-            .findOrInit(key) { UnitCallback(key) }
+            .findOrInit(key) { UnitCallbackImpl(key) }
             .requestAccess {
                 duplicateKeyErrorMessage(key)
-            } as UnitCallback
+            } as UnitCallbackImpl
     }
 
-    fun <UIEvent> initOrFindCallbackT(key: Any): Callback<UIEvent> {
+    fun <UIEvent> initOrFindCallbackT(key: Any): CallbackImpl<UIEvent> {
         val callbacks = callbacks ?: run {
-            val initialized: SingleRequestMap<Any, Callback<*>> = mutableMapOf()
+            val initialized: SingleRequestMap<Any, CallbackImpl<*>> = mutableMapOf()
             this.callbacks = initialized
             initialized
         }
 
         return callbacks
-            .findOrInit(key) { Callback<UIEvent>(key) }
+            .findOrInit(key) { CallbackImpl<UIEvent>(key) }
             .requestAccess {
                 duplicateKeyErrorMessage(key)
-            } as Callback<UIEvent>
+            } as CallbackImpl<UIEvent>
     }
 
     fun evaluationFinished() {

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
@@ -7,7 +7,7 @@ import java.lang.IllegalStateException
 
 class FormulaContextImpl<State> internal constructor(
     private val transitionId: TransitionId,
-    callbacks: ScopedCallbacks,
+    callbacks: ScopedCallbacks<State>,
     private val delegate: Delegate,
     transitionDispatcher: TransitionDispatcher<State>
 ) : FormulaContext<State>(callbacks, transitionDispatcher) {

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
@@ -2,7 +2,6 @@ package com.instacart.formula.internal
 
 import com.instacart.formula.FormulaContext
 import com.instacart.formula.IFormula
-import com.instacart.formula.Transition
 import com.instacart.formula.BoundStream
 import java.lang.IllegalStateException
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaContextImpl.kt
@@ -22,7 +22,7 @@ class FormulaContextImpl<State> internal constructor(
 
     override fun updates(init: UpdateBuilder<State>.() -> Unit): List<BoundStream<*>> {
         ensureNotRunning()
-        val builder = UpdateBuilder(transitionDispatcher)
+        val builder = UpdateBuilder(this)
         builder.init()
         return builder.updates
     }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -176,13 +176,13 @@ internal class FormulaManagerImpl<Input, State, Output>(
     override fun markAsTerminated() {
         terminated = true
         frame?.transitionDispatcher?.terminated = true
-        callbacks.disableAll()
         children?.forEachValue { it.markAsTerminated() }
     }
 
     override fun performTerminationSideEffects() {
         children?.forEachValue { it.performTerminationSideEffects() }
         updateManager.terminate()
+        callbacks.disableAll()
     }
 
     private fun <ChildInput, ChildOutput> constructKey(

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -17,7 +17,7 @@ import com.instacart.formula.Transition
 internal class FormulaManagerImpl<Input, State, Output>(
     private val formula: Formula<Input, State, Output>,
     initialInput: Input,
-    private val callbacks: ScopedCallbacks,
+    private val callbacks: ScopedCallbacks<State>,
     private val transitionListener: TransitionListener
 ) : FormulaContextImpl.Delegate, FormulaManager<Input, Output> {
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -56,7 +56,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
 
     override fun updateTransitionId(transitionId: TransitionId) {
         val lastFrame = checkNotNull(frame) { "missing frame means this is called before initial evaluate" }
-        lastFrame.transitionCallbackWrapper.transitionId = transitionId
+        lastFrame.transitionDispatcher.transitionId = transitionId
 
         children?.forEachValue { it.updateTransitionId(transitionId) }
     }
@@ -81,10 +81,10 @@ internal class FormulaManagerImpl<Input, State, Output>(
         }
 
         callbacks.evaluationStarted()
-        val transitionCallback = TransitionCallbackWrapper(this::handleTransition, transitionId)
-        val context = FormulaContextImpl(transitionId, callbacks, this, transitionCallback)
+        val transitionDispatcher = TransitionDispatcher(this::handleTransition, transitionId)
+        val context = FormulaContextImpl(transitionId, callbacks, this, transitionDispatcher)
         val result = formula.evaluate(input, state, context)
-        val frame = Frame(input, state, result, transitionCallback)
+        val frame = Frame(input, state, result, transitionDispatcher)
         updateManager.updateEventListeners(frame.evaluation.updates)
         this.frame = frame
 
@@ -96,7 +96,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
             pendingRemoval?.add(it)
         }
 
-        transitionCallback.running = true
+        transitionDispatcher.running = true
         return result
     }
 
@@ -175,7 +175,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
 
     override fun markAsTerminated() {
         terminated = true
-        frame?.transitionCallbackWrapper?.terminated = true
+        frame?.transitionDispatcher?.terminated = true
         callbacks.disableAll()
         children?.forEachValue { it.markAsTerminated() }
     }

--- a/formula/src/main/java/com/instacart/formula/internal/Frame.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/Frame.kt
@@ -10,7 +10,7 @@ internal class Frame<Input, State, Output>(
     val input: Input,
     val state: State,
     val evaluation: Evaluation<Output>,
-    val transitionCallbackWrapper: TransitionCallbackWrapper<State>
+    val transitionDispatcher: TransitionDispatcher<State>
 ) {
     private var stateValid: Boolean = true
     private var childrenValid: Boolean = true

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -17,7 +17,7 @@ internal class ScopedCallbacks<State> private constructor(
 
     internal var enabled: Boolean = false
 
-    fun <Event> initOrFindEventCallback(key: Any): CallbackImpl<State, Event> {
+    fun <Event> initOrFindCallback(key: Any): CallbackImpl<State, Event> {
         ensureNotRunning()
         return currentCallbacks().initOrFindCallback<Event>(key)
     }

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -17,12 +17,12 @@ internal class ScopedCallbacks private constructor(
 
     internal var enabled: Boolean = false
 
-    fun initOrFindCallback(key: Any): UnitCallback {
+    fun initOrFindCallback(key: Any): UnitCallbackImpl {
         ensureNotRunning()
         return currentCallbacks().initOrFindCallbackT(key)
     }
 
-    fun <UIEvent> initOrFindEventCallback(key: Any): Callback<UIEvent> {
+    fun <UIEvent> initOrFindEventCallback(key: Any): CallbackImpl<UIEvent> {
         ensureNotRunning()
         return currentCallbacks().initOrFindCallbackT<UIEvent>(key)
     }

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -17,9 +17,9 @@ internal class ScopedCallbacks<State> private constructor(
 
     internal var enabled: Boolean = false
 
-    fun <UIEvent> initOrFindEventCallback(key: Any): CallbackImpl<State, UIEvent> {
+    fun <Event> initOrFindEventCallback(key: Any): CallbackImpl<State, Event> {
         ensureNotRunning()
-        return currentCallbacks().initOrFindCallback<UIEvent>(key)
+        return currentCallbacks().initOrFindCallback<Event>(key)
     }
 
     fun enterScope(key: Any) {

--- a/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ScopedCallbacks.kt
@@ -3,28 +3,23 @@ package com.instacart.formula.internal
 import com.instacart.formula.IFormula
 
 @PublishedApi
-internal class ScopedCallbacks private constructor(
+internal class ScopedCallbacks<State> private constructor(
     private val rootKey: Any
 ) {
     constructor(formula: IFormula<*, *>) : this(formula::class)
 
-    private var callbacks: SingleRequestMap<Any, Callbacks>? = null
+    private var callbacks: SingleRequestMap<Any, Callbacks<State>>? = null
 
-    private var lastCallbacks: Callbacks? = null
+    private var lastCallbacks: Callbacks<State>? = null
     private var lastKey: Any? = null
     private var currentKey: Any = rootKey
-    private var current: Callbacks? = null
+    private var current: Callbacks<State>? = null
 
     internal var enabled: Boolean = false
 
-    fun initOrFindCallback(key: Any): UnitCallbackImpl {
+    fun <UIEvent> initOrFindEventCallback(key: Any): CallbackImpl<State, UIEvent> {
         ensureNotRunning()
-        return currentCallbacks().initOrFindCallbackT(key)
-    }
-
-    fun <UIEvent> initOrFindEventCallback(key: Any): CallbackImpl<UIEvent> {
-        ensureNotRunning()
-        return currentCallbacks().initOrFindCallbackT<UIEvent>(key)
+        return currentCallbacks().initOrFindCallback<UIEvent>(key)
     }
 
     fun enterScope(key: Any) {
@@ -85,9 +80,9 @@ internal class ScopedCallbacks private constructor(
         callbacks?.clear()
     }
 
-    private fun currentCallbacks(): Callbacks {
+    private fun currentCallbacks(): Callbacks<State> {
         val callbacks = callbacks ?: run {
-            val initialized: SingleRequestMap<Any, Callbacks> = mutableMapOf()
+            val initialized: SingleRequestMap<Any, Callbacks<State>> = mutableMapOf()
             this.callbacks = initialized
             initialized
         }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -2,14 +2,15 @@ package com.instacart.formula.internal
 
 import com.instacart.formula.Transition
 
-internal class TransitionCallbackWrapper<State>(
+@PublishedApi
+internal class TransitionDispatcher<State>(
     private val handleTransition: (Transition<State>) -> Unit,
     var transitionId: TransitionId
-) : (Transition<State>) -> Unit {
+) {
     var running = false
     var terminated = false
 
-    override fun invoke(transition: Transition<State>) {
+    fun dispatch(transition: Transition<State>) {
         if (!running) {
             throw IllegalStateException("Transitions are not allowed during evaluation")
         }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -1,7 +1,7 @@
 package com.instacart.formula.internal
 
 import com.instacart.formula.Transition
-import com.instacart.formula.UpdateType
+import com.instacart.formula.Update
 
 @PublishedApi
 internal class TransitionDispatcher<State>(
@@ -29,7 +29,7 @@ internal class TransitionDispatcher<State>(
     }
 
     // TODO: naming UpdateType as transition seems weird. We need to resolve these two types.
-    fun <Event> dispatch(transition: UpdateType<State, Event>, event: Event) {
+    fun <Event> dispatch(transition: Update<State, Event>, event: Event) {
         val transition = Transition.Factory.run { transition.run { create(event) } }
         dispatch(transition)
     }
@@ -39,7 +39,7 @@ internal class TransitionDispatcher<State>(
      * call-site because we will use the type as key.
      */
     fun <Event> toCallback(
-        update: UpdateType<State, Event>
+        update: Update<State, Event>
     ): (Event) -> Unit {
         return {
             val transition = Transition.Factory.run { update.run { create(it) } }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -3,7 +3,6 @@ package com.instacart.formula.internal
 import com.instacart.formula.Transition
 import com.instacart.formula.Update
 
-@PublishedApi
 internal class TransitionDispatcher<State>(
     private val handleTransition: (Transition<State>) -> Unit,
     var transitionId: TransitionId
@@ -32,18 +31,5 @@ internal class TransitionDispatcher<State>(
     fun <Event> dispatch(transition: Update<State, Event>, event: Event) {
         val transition = Transition.Factory.run { transition.run { create(event) } }
         dispatch(transition)
-    }
-
-    /**
-     * We define this as inline function because we want to generate an anonymous class at the
-     * call-site because we will use the type as key.
-     */
-    fun <Event> toCallback(
-        update: Update<State, Event>
-    ): (Event) -> Unit {
-        return {
-            val transition = Transition.Factory.run { update.run { create(it) } }
-            dispatch(transition)
-        }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula.internal
 
 import com.instacart.formula.Transition
+import com.instacart.formula.UpdateType
 
 @PublishedApi
 internal class TransitionDispatcher<State>(
@@ -25,5 +26,18 @@ internal class TransitionDispatcher<State>(
         }
 
         handleTransition(transition)
+    }
+
+    /**
+     * We define this as inline function because we want to generate an anonymous class at the
+     * call-site because we will use the type as key.
+     */
+    fun <Event> toCallback(
+        update: UpdateType<State, Event>
+    ): (Event) -> Unit {
+        return {
+            val transition = Transition.Factory.run { update.run { create(it) } }
+            dispatch(transition)
+        }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -28,6 +28,12 @@ internal class TransitionDispatcher<State>(
         handleTransition(transition)
     }
 
+    // TODO: naming UpdateType as transition seems weird. We need to resolve these two types.
+    fun <Event> dispatch(transition: UpdateType<State, Event>, event: Event) {
+        val transition = Transition.Factory.run { transition.run { create(event) } }
+        dispatch(transition)
+    }
+
     /**
      * We define this as inline function because we want to generate an anonymous class at the
      * call-site because we will use the type as key.

--- a/formula/src/test/java/com/instacart/formula/subjects/ChildRemovedOnMessage.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ChildRemovedOnMessage.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula.subjects
 
 import com.google.common.truth.Truth
+import com.instacart.formula.invoke
 import com.instacart.formula.test.TestableRuntime
 
 class ChildRemovedOnMessage(runtime: TestableRuntime) {

--- a/formula/src/test/java/com/instacart/formula/subjects/ChildStreamEvents.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ChildStreamEvents.kt
@@ -1,6 +1,7 @@
 package com.instacart.formula.subjects
 
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.invoke
 import com.instacart.formula.test.TestableRuntime
 
 class ChildStreamEvents(runtime: TestableRuntime) {

--- a/formula/src/test/java/com/instacart/formula/subjects/DelegateFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/DelegateFormula.kt
@@ -25,7 +25,7 @@ class DelegateFormula<Type>(
         return Evaluation(
             output = Output(
                 childValue = context.child(childFormula, state),
-                changeChildInput = context.onEvent { name -> transition(name) }
+                changeChildInput = context.onEvent<Type> { name -> transition(name) }
             )
         )
     }

--- a/formula/src/test/java/com/instacart/formula/subjects/DynamicParentFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/DynamicParentFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class DynamicParentFormula(
     private val childFormula: KeyFormula = KeyFormula()
@@ -16,7 +17,7 @@ class DynamicParentFormula(
         val children: List<TestOutput> = emptyList(),
         val addChild: (TestKey) -> Unit,
         val removeChild: (TestKey) -> Unit,
-        val removeAllChildren: () -> Unit,
+        val removeAllChildren: Listener<Unit>,
     )
 
     override fun initialState(input: Unit): State = State()

--- a/formula/src/test/java/com/instacart/formula/subjects/EffectOrderFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/EffectOrderFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.Stream
 
 class EffectOrderFormula : Formula<EffectOrderFormula.Input, EffectOrderFormula.State, EffectOrderFormula.Output> {
@@ -24,7 +25,7 @@ class EffectOrderFormula : Formula<EffectOrderFormula.Input, EffectOrderFormula.
     }
 
     data class Output(
-        val triggerEvent: () -> Unit
+        val triggerEvent: Listener<Unit>
     )
 
     override fun initialState(input: Input): State = State()

--- a/formula/src/test/java/com/instacart/formula/subjects/EventCallbackFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/EventCallbackFormula.kt
@@ -17,7 +17,7 @@ class EventCallbackFormula : Formula<Unit, String, EventCallbackFormula.Output> 
         return Evaluation(
             output = Output(
                 state = state,
-                changeState = context.onEvent { newState ->
+                changeState = context.onEvent<String> { newState ->
                     transition(newState)
                 }
             )

--- a/formula/src/test/java/com/instacart/formula/subjects/KeyUsingListFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/KeyUsingListFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.test.TestableRuntime
 
 class KeyUsingListFormula :
@@ -17,7 +18,7 @@ class KeyUsingListFormula :
 
     data class ItemRenderModel(
         val item: String,
-        val onDeleteSelected: () -> Unit
+        val onDeleteSelected: Listener<Unit>
     )
 
     data class Input(val items: List<String>)

--- a/formula/src/test/java/com/instacart/formula/subjects/MessageFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/MessageFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class MessageFormula : Formula<MessageFormula.Input, Int, MessageFormula.Output> {
 
@@ -10,8 +11,8 @@ class MessageFormula : Formula<MessageFormula.Input, Int, MessageFormula.Output>
 
     class Output(
         val state: Int,
-        val triggerMessage: () -> Unit,
-        val incrementAndMessage: () -> Unit
+        val triggerMessage: Listener<Unit>,
+        val incrementAndMessage: Listener<Unit>,
     )
 
     override fun initialState(input: Input): Int = 0

--- a/formula/src/test/java/com/instacart/formula/subjects/MixingCallbackUseWithKeyUse.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/MixingCallbackUseWithKeyUse.kt
@@ -3,13 +3,14 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class MixingCallbackUseWithKeyUse {
 
     class ParentOutput(
-        val firstCallback: () -> Unit,
-        val secondCallback: () -> Unit,
-        val thirdCallback: () -> Unit
+        val firstCallback: Listener<Unit>,
+        val secondCallback: Listener<Unit>,
+        val thirdCallback: Listener<Unit>,
     )
 
     class ParentFormula : Formula<Unit, Unit, ParentOutput> {

--- a/formula/src/test/java/com/instacart/formula/subjects/NestedKeyFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/NestedKeyFormula.kt
@@ -3,10 +3,11 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class NestedKeyFormula : Formula<Unit, Unit, NestedKeyFormula.Output> {
 
-    class Output(val callback: () -> Unit)
+    class Output(val callback: Listener<Unit>)
 
     override fun initialState(input: Unit) = Unit
 
@@ -18,7 +19,7 @@ class NestedKeyFormula : Formula<Unit, Unit, NestedKeyFormula.Output> {
 
         val callback = context.key("first level") {
             context.key("second level") {
-                context.onEvent {
+                context.onEvent<Unit> {
                     none()
                 }
             }

--- a/formula/src/test/java/com/instacart/formula/subjects/NestedTerminationWithInputChanged.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/NestedTerminationWithInputChanged.kt
@@ -41,7 +41,7 @@ class NestedTerminationWithInputChanged: Formula<Boolean, Boolean, Output> {
         context: FormulaContext<Boolean>
     ): Evaluation<Output> {
         // We use a callback to check if formula runtime is in the right state.
-        context.onEvent { none() }
+        context.onEvent<Unit> { none() }
         context.child(passThroughFormula, state)
 
         return Evaluation(

--- a/formula/src/test/java/com/instacart/formula/subjects/OptionalCallbackFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OptionalCallbackFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class OptionalCallbackFormula :
     Formula<Unit, OptionalCallbackFormula.State, OptionalCallbackFormula.Output> {
@@ -13,15 +14,15 @@ class OptionalCallbackFormula :
 
     data class Output(
         val state: Int,
-        val callback: (() -> Unit)?,
-        val toggleCallback: () -> Unit
+        val callback: Listener<Unit>?,
+        val toggleCallback: Listener<Unit>,
     )
 
     override fun initialState(input: Unit) = State()
 
     override fun evaluate(input: Unit, state: State, context: FormulaContext<State>): Evaluation<Output> {
         val callback = if (state.callbackEnabled) {
-            context.onEvent { transition(state.copy(state = state.state + 1)) }
+            context.onEvent<Unit> { transition(state.copy(state = state.state + 1)) }
         } else {
             null
         }

--- a/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
@@ -4,6 +4,7 @@ import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
 import com.instacart.formula.IFormula
+import com.instacart.formula.Listener
 
 class OptionalChildFormula<ChildInput, ChildOutput>(
     private val child: IFormula<ChildInput, ChildOutput>,
@@ -21,7 +22,7 @@ class OptionalChildFormula<ChildInput, ChildOutput>(
 
     class Output<ChildOutput>(
         val child: ChildOutput?,
-        val toggleChild: () -> Unit
+        val toggleChild: Listener<Unit>,
     )
 
     override fun initialState(input: Unit) = State()

--- a/formula/src/test/java/com/instacart/formula/subjects/OptionalEventCallbackFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OptionalEventCallbackFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class OptionalEventCallbackFormula :
     Formula<Unit, OptionalEventCallbackFormula.State, OptionalEventCallbackFormula.Output> {
@@ -13,8 +14,8 @@ class OptionalEventCallbackFormula :
 
     data class Output(
         val state: Int,
-        val callback: ((Int) -> Unit)?,
-        val toggleCallback: () -> Unit
+        val callback: Listener<Int>?,
+        val toggleCallback: Listener<Unit>
     )
 
     override fun initialState(input: Unit) = State()

--- a/formula/src/test/java/com/instacart/formula/subjects/RootFormulaKeyTestSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/RootFormulaKeyTestSubject.kt
@@ -4,6 +4,8 @@ import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
+import com.instacart.formula.invoke
 import com.instacart.formula.test.TestableRuntime
 
 class RootFormulaKeyTestSubject(runtime: TestableRuntime) {
@@ -12,7 +14,7 @@ class RootFormulaKeyTestSubject(runtime: TestableRuntime) {
     private val subject = runtime.test(MyFormula, input)
 
     fun increment() = apply {
-        subject.output { increment() }
+        subject.output { this.increment() }
     }
 
     fun assertValue(value: Int) = apply {
@@ -29,7 +31,7 @@ class RootFormulaKeyTestSubject(runtime: TestableRuntime) {
 
     data class Output(
         val value: Int,
-        val increment: () -> Unit
+        val increment: Listener<Unit>,
     )
 
     object MyFormula : Formula<Int, Int, Output> {

--- a/formula/src/test/java/com/instacart/formula/subjects/SideEffectFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/SideEffectFormula.kt
@@ -3,13 +3,14 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 
 class SideEffectFormula(
     private val onSideEffect: () -> Unit
 ) : Formula<Unit, Int, SideEffectFormula.Output> {
 
     class Output(
-        val triggerSideEffect: () -> Unit
+        val triggerSideEffect: Listener<Unit>
     )
 
     override fun initialState(input: Unit): Int = 0

--- a/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.subjects.StartStopFormula.Output
 import com.instacart.formula.subjects.StartStopFormula.State
 import com.instacart.formula.test.TestableRuntime
@@ -18,8 +19,8 @@ class StartStopFormula(runtime: TestableRuntime) : Formula<Unit, State, Output> 
 
     class Output(
         val state: Int,
-        val startListening: () -> Unit,
-        val stopListening: () -> Unit
+        val startListening: Listener<Unit>,
+        val stopListening: Listener<Unit>,
     )
 
     override fun initialState(input: Unit): State = State()

--- a/formula/src/test/java/com/instacart/formula/subjects/StateTransitionTimingFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StateTransitionTimingFormula.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.subjects
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.test.TestableRuntime
 
 class StateTransitionTimingFormula(
@@ -14,7 +15,10 @@ class StateTransitionTimingFormula(
         EXTERNAL
     }
 
-    data class Output(val events: List<State>, val onStateTransition: () -> Unit)
+    data class Output(
+        val events: List<State>,
+        val onStateTransition: Listener<Unit>,
+    )
 
     private val relay = runtime.newRelay()
 

--- a/formula/src/test/java/com/instacart/formula/subjects/UsingCallbacksWithinAnotherFunction.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/UsingCallbacksWithinAnotherFunction.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.subjects
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.StatelessFormula
 import com.instacart.formula.test.TestableRuntime
 
@@ -10,8 +11,8 @@ object UsingCallbacksWithinAnotherFunction {
     fun test(runtime: TestableRuntime) = runtime.test(TestFormula(), Unit)
 
     class TestOutput(
-        val first: () -> Unit,
-        val second: () -> Unit
+        val first: Listener<Unit>,
+        val second: Listener<Unit>,
     )
 
     class TestFormula : StatelessFormula<Unit, TestOutput>() {
@@ -24,7 +25,7 @@ object UsingCallbacksWithinAnotherFunction {
             )
         }
 
-        private fun createDefaultCallback(context: FormulaContext<Unit>): () -> Unit {
+        private fun createDefaultCallback(context: FormulaContext<Unit>): Listener<Unit> {
             return context.onEvent {
                 none()
             }

--- a/formula/src/test/java/com/instacart/formula/subjects/UsingKeyToScopeCallbacksWithinAnotherFunction.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/UsingKeyToScopeCallbacksWithinAnotherFunction.kt
@@ -2,12 +2,13 @@ package com.instacart.formula.subjects
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.FormulaContext
+import com.instacart.formula.Listener
 import com.instacart.formula.StatelessFormula
 
 object UsingKeyToScopeCallbacksWithinAnotherFunction {
 
     class ChildOutput(
-        val callback: () -> Unit
+        val callback: Listener<Unit>,
     )
 
     class TestOutput(

--- a/samples/composition/src/main/java/com/instacart/formula/samples/composition/ItemPageRenderView.kt
+++ b/samples/composition/src/main/java/com/instacart/formula/samples/composition/ItemPageRenderView.kt
@@ -13,6 +13,7 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.instacart.formula.Renderer
 import com.instacart.formula.RenderView
+import com.instacart.formula.invoke
 import com.instacart.formula.samples.composition.item.ItemRenderModel
 
 class ItemPageRenderView(private val root: ViewGroup): RenderView<ItemPageRenderModel> {

--- a/samples/composition/src/main/java/com/instacart/formula/samples/composition/item/ItemRenderModel.kt
+++ b/samples/composition/src/main/java/com/instacart/formula/samples/composition/item/ItemRenderModel.kt
@@ -1,9 +1,11 @@
 package com.instacart.formula.samples.composition.item
 
+import com.instacart.formula.Listener
+
 data class ItemRenderModel(
     val name: String,
     val displayQuantity: String,
     val isDecrementEnabled: Boolean,
-    val onDecrement: () -> Unit,
-    val onIncrement: () -> Unit
+    val onDecrement: Listener<Unit>,
+    val onIncrement: Listener<Unit>,
 )

--- a/samples/counter/src/main/java/com/instacart/formula/counter/CounterRenderModel.kt
+++ b/samples/counter/src/main/java/com/instacart/formula/counter/CounterRenderModel.kt
@@ -1,7 +1,9 @@
 package com.instacart.formula.counter
 
+import com.instacart.formula.Listener
+
 data class CounterRenderModel(
     val count: String,
-    val onDecrement: () -> Unit,
-    val onIncrement: () -> Unit
+    val onDecrement: Listener<Unit>,
+    val onIncrement: Listener<Unit>,
 )

--- a/samples/counter/src/main/java/com/instacart/formula/counter/CounterRenderView.kt
+++ b/samples/counter/src/main/java/com/instacart/formula/counter/CounterRenderView.kt
@@ -5,6 +5,7 @@ import android.widget.Button
 import android.widget.TextView
 import com.instacart.formula.Renderer
 import com.instacart.formula.RenderView
+import com.instacart.formula.invoke
 
 class CounterRenderView(private val root: ViewGroup): RenderView<CounterRenderModel> {
     private val decrementButton: Button = root.findViewById(R.id.decrement_button)

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFeatureFactory.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFeatureFactory.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.unit.Dp
 import com.instacart.formula.android.Feature
 import com.instacart.formula.android.FeatureFactory
 import com.instacart.formula.android.compose.ComposeViewFactory
+import com.instacart.formula.invoke
 import com.instacart.formula.rxjava3.toObservable
 
 class StopwatchFeatureFactory : FeatureFactory<Any, StopwatchKey> {
@@ -56,7 +57,7 @@ class StopwatchViewFactory : ComposeViewFactory<StopwatchRenderModel>() {
     @Composable
     fun StopwatchButton(model: ButtonRenderModel) {
         Button(
-            onClick = model.onSelected,
+            onClick = model.onSelected::invoke,
             colors = ButtonDefaults.buttonColors(
                 backgroundColor = Color.Gray,
             ),

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchRenderModels.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchRenderModels.kt
@@ -1,5 +1,7 @@
 package com.instacart.formula.compose.stopwatch
 
+import com.instacart.formula.Listener
+
 data class StopwatchRenderModel(
     val timePassed: String,
     val startStopButton: ButtonRenderModel,
@@ -8,5 +10,5 @@ data class StopwatchRenderModel(
 
 data class ButtonRenderModel(
     val text: String,
-    val onSelected: () -> Unit
+    val onSelected: Listener<Unit>,
 )

--- a/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchRenderModels.kt
+++ b/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchRenderModels.kt
@@ -1,5 +1,7 @@
 package com.instacart.formula.stopwatch
 
+import com.instacart.formula.Listener
+
 data class StopwatchRenderModel(
     val timePassed: String,
     val startStopButton: ButtonRenderModel,
@@ -8,5 +10,5 @@ data class StopwatchRenderModel(
 
 data class ButtonRenderModel(
     val text: String,
-    val onSelected: () -> Unit
+    val onSelected: Listener<Unit>
 )

--- a/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchRenderView.kt
+++ b/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchRenderView.kt
@@ -5,6 +5,7 @@ import android.widget.Button
 import android.widget.TextView
 import com.instacart.formula.Renderer
 import com.instacart.formula.RenderView
+import com.instacart.formula.invoke
 
 class StopwatchRenderView(root: ViewGroup): RenderView<StopwatchRenderModel> {
     private val timePassed: TextView = root.findViewById(R.id.time_passed_text_view)

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskFilterRenderModel.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskFilterRenderModel.kt
@@ -1,3 +1,8 @@
 package com.examples.todoapp.tasks
 
-data class TaskFilterRenderModel(val title: String, val onSelected: () -> Unit)
+import com.instacart.formula.Listener
+
+data class TaskFilterRenderModel(
+    val title: String,
+    val onSelected: Listener<Unit>,
+)

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskItemRenderModel.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskItemRenderModel.kt
@@ -1,9 +1,11 @@
 package com.examples.todoapp.tasks
 
+import com.instacart.formula.Listener
+
 class TaskItemRenderModel(
     val id: String,
     val text: String,
     val isSelected: Boolean,
-    val onClick: () -> Unit,
-    val onToggle: () -> Unit
+    val onClick: Listener<Unit>,
+    val onToggle: Listener<Unit>,
 )

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListRenderView.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListRenderView.kt
@@ -15,6 +15,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.examples.todoapp.R
 import com.instacart.formula.Renderer
 import com.instacart.formula.RenderView
+import com.instacart.formula.invoke
 
 class TaskListRenderView(private val root: View) : RenderView<TaskListRenderModel> {
     private val toolbar: Toolbar = root.findViewById(R.id.toolbar)


### PR DESCRIPTION
## What
Added new `Update<State, Event>` type which is a function that creates the `Transition` object. Maybe those two types should merge into `Update` and `Update.Result` or `Transition` and `Transition.Result` ?
