### PR TITLE
Improving transition composition.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/TransitionContext.kt
+++ b/formula/src/main/java/com/instacart/formula/TransitionContext.kt
@@ -1,12 +1,16 @@
 package com.instacart.formula
 
+import com.instacart.formula.internal.DelegateTransitionContext
+import com.instacart.formula.internal.combine
+import com.instacart.formula.internal.toResult
+
 /**
  * Transition context provides the current [state] and utilities to help
  * create [Transition.Result] within [Transition.toResult].
  *
  * TODO: add Formula.Input as well.
  */
-interface TransitionContext<out State> {
+interface TransitionContext<State> {
 
     val state: State
 
@@ -36,4 +40,65 @@ interface TransitionContext<out State> {
     ): Transition.Result.OnlyEffects {
         return Transition.Result.OnlyEffects(effects)
     }
+
+    /**
+     * Delegates to another [Transition] to provide the result.
+     */
+    fun <Event> delegate(transition: Transition<State, Event>, event: Event): Transition.Result<State> {
+        return transition.run { toResult(event) }
+    }
+
+    /**
+     * Delegates to another [Transition] that has [Unit] event type to provide the result.
+     */
+    fun delegate(transition: Transition<State, Unit>): Transition.Result<State> {
+        return delegate(transition, Unit)
+    }
+
+    /**
+     * Function used to chain multiple transitions together.
+     */
+    fun <Event> Transition.Result<State>.andThen(
+        transition: Transition<State, Event>,
+        event: Event
+    ): Transition.Result<State> {
+        return when (this) {
+            Transition.Result.None -> {
+                transition.toResult(this@TransitionContext, event)
+            }
+            is Transition.Result.OnlyEffects -> {
+                combine(this, transition.toResult(this@TransitionContext, event))
+            }
+            is Transition.Result.Stateful -> {
+                combine(this, transition.toResult(DelegateTransitionContext(this.state), event))
+            }
+        }
+    }
+
+    /**
+     * Function used to chain multiple transitions together.
+     */
+    fun Transition.Result<State>.andThen(
+        transition: Transition<State, Unit>,
+    ): Transition.Result<State> {
+        return andThen(transition, Unit)
+    }
+
+    /**
+     * Function to chain updated state with another transition.
+     */
+    fun <Event> State.andThen(
+        transition: Transition<State, Event>,
+        event: Event
+    ): Transition.Result<State> {
+        return transition(this).andThen(transition, event)
+    }
+
+    /**
+     * Function to chain updated state with another transition.
+     */
+    fun State.andThen(transition: Transition<State, Unit>): Transition.Result<State> {
+        return transition(this).andThen(transition)
+    }
 }
+

--- a/formula/src/main/java/com/instacart/formula/internal/DelegateTransitionContext.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/DelegateTransitionContext.kt
@@ -1,0 +1,5 @@
+package com.instacart.formula.internal
+
+import com.instacart.formula.TransitionContext
+
+internal class DelegateTransitionContext<State>(override val state: State): TransitionContext<State>

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -32,7 +32,15 @@ internal class TransitionDispatcher<State>(
         transition: Transition<State, Event>,
         event: Event
     ) {
-        val result = transition.run { toResult(event) }
+        val result = transition.toResult(this, event)
         dispatch(result)
     }
+}
+
+
+internal fun <State, Event> Transition<State, Event>.toResult(
+    context: TransitionContext<State>,
+    event: Event
+): Transition.Result<State> {
+    return context.run { toResult(event) }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
@@ -1,10 +1,63 @@
 package com.instacart.formula.internal
 
 import com.instacart.formula.Transition
+import com.instacart.formula.TransitionContext
 
 internal object TransitionUtils {
 
     fun isEmpty(result: Transition.Result<*>): Boolean {
         return result == Transition.Result.None
+    }
+}
+
+/**
+ * Combines only effects transition result with another transition result.
+ */
+internal fun <State> TransitionContext<State>.combine(
+    result: Transition.Result.OnlyEffects,
+    other: Transition.Result<State>
+): Transition.Result<State> {
+    return when(other) {
+        Transition.Result.None -> {
+            result
+        }
+        is Transition.Result.OnlyEffects -> {
+            transition {
+                result.effects.execute()
+                other.effects.execute()
+            }
+        }
+        is Transition.Result.Stateful -> {
+            transition(other.state) {
+                result.effects.execute()
+                other.effects?.execute()
+            }
+        }
+    }
+}
+
+/**
+ * Combines stateful result with the result of another transition.
+ */
+internal fun <State> TransitionContext<State>.combine(
+    result: Transition.Result.Stateful<State>,
+    other: Transition.Result<State>
+): Transition.Result<State> {
+    return when(other) {
+        Transition.Result.None -> {
+            result
+        }
+        is Transition.Result.OnlyEffects -> {
+            transition(result.state) {
+                result.effects?.execute()
+                other.effects.execute()
+            }
+        }
+        is Transition.Result.Stateful -> {
+            transition(other.state) {
+                result.effects?.execute()
+                other.effects?.execute()
+            }
+        }
     }
 }

--- a/formula/src/test/java/com/instacart/formula/TransitionApiTest.kt
+++ b/formula/src/test/java/com/instacart/formula/TransitionApiTest.kt
@@ -1,0 +1,151 @@
+package com.instacart.formula
+
+import com.google.common.truth.Truth
+import com.instacart.formula.internal.DelegateTransitionContext
+import com.instacart.formula.internal.toResult
+import com.instacart.formula.test.TestListener
+import org.junit.Test
+
+class TransitionApiTest {
+
+    @Test fun `none transition`() {
+        val transition = Transition<Int, Unit> { none() }
+        val result = transition.toResult(FakeTransitionContext(0), Unit)
+        Truth.assertThat(result).isEqualTo(Transition.Result.None)
+    }
+
+    @Test fun `stateful transition`() {
+        val transition = Transition<Int, Unit> { transition(state + 1) }
+        val result = transition.toResult(FakeTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(1)
+    }
+
+    @Test fun `stateful transition with effects`() {
+        val testListener = TestListener<Unit>()
+        val transition = Transition<Int, Unit> {
+            transition(state + 1) {
+                testListener.invoke(Unit)
+            }
+        }
+
+        val result = transition.toResult(FakeTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(1)
+
+        result.assertAndExecuteEffects()
+        testListener.assertTimesCalled(1)
+    }
+
+    @Test fun `only effects transitions`() {
+        val testListener = TestListener<Unit>()
+        val transition = Transition<Int, Unit> {
+            transition {
+                testListener.invoke(Unit)
+            }
+        }
+
+        val result = transition.toResult(FakeTransitionContext(0), Unit)
+        result.assertAndExecuteEffects()
+        testListener.assertTimesCalled(1)
+    }
+
+    @Test
+    fun `transition delegates to another transition`() {
+        val transition = Transition<Int, Unit> {
+            delegate(AddTransition(), 5)
+        }
+        val result = transition.toResult(FakeTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(5)
+    }
+
+    @Test fun `transition combine none transition with stateful transition`() {
+        val transition = Transition<Int, Unit> {
+            none().andThen(AddTransition(), 1)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(1)
+    }
+
+    @Test fun `transition combine only effects transition with stateful transition`() {
+        val testListener = TestListener<Unit>()
+        val transition = Transition<Int, Unit> {
+            val result = transition { testListener.invoke(Unit) }
+            result.andThen(AddTransition(), 1)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(1)
+
+        result.assertAndExecuteEffects()
+        testListener.assertTimesCalled(1)
+    }
+
+    @Test fun `transition combine stateful transition with another transition`() {
+        val transition = Transition<Int, Unit> {
+            transition(state + 1).andThen(AddTransition(), 1)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(2)
+    }
+
+    @Test fun `transition combine keeps effect order`() {
+        val listener = TestListener<Int>()
+        val incrementAndNotify = IncrementAndNotifyTransition(listener)
+        val transition = Transition<Int, Unit> {
+            delegate(incrementAndNotify).andThen(incrementAndNotify)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(2)
+
+        result.assertAndExecuteEffects()
+        Truth.assertThat(listener.values()).containsExactly(1, 2).inOrder()
+    }
+
+    @Test fun `state andThen another stateful result`() {
+        val transition = Transition<Int, Unit> {
+            (state + 1).andThen(AddTransition(), 2)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(3)
+    }
+
+    @Test fun `state andThen empty result`() {
+        val transition = Transition<Int, Unit> {
+            val empty = Transition<Int, Unit> { none() }
+            (state + 1).andThen(empty)
+        }
+
+        val result = transition.toResult(DelegateTransitionContext(0), Unit).assertStateful()
+        Truth.assertThat(result.state).isEqualTo(1)
+    }
+
+    private fun <State> Transition.Result<State>.assertStateful(): Transition.Result.Stateful<State> {
+        Truth.assertThat(this).isInstanceOf(Transition.Result.Stateful::class.java)
+        return this as Transition.Result.Stateful<State>
+    }
+
+    private fun <State> Transition.Result<State>.assertAndExecuteEffects() {
+        Truth.assertThat(effects).isNotNull()
+        effects?.execute()
+    }
+
+    class AddTransition : Transition<Int, Int> {
+        override fun TransitionContext<Int>.toResult(event: Int): Transition.Result<Int> {
+            return transition(state + event)
+        }
+    }
+
+    class IncrementAndNotifyTransition(private val listener: Listener<Int>): Transition<Int, Unit> {
+        override fun TransitionContext<Int>.toResult(event: Unit): Transition.Result<Int> {
+            val newState = state + 1
+            return transition(newState) {
+                listener.invoke(newState)
+            }
+        }
+    }
+
+    class FakeTransitionContext<State>(override val state: State) : TransitionContext<State>
+}


### PR DESCRIPTION
## What
As a follow-up to #247, I'm adding some utilities to:
- delegate to another transition within transition block
```kotlin
val transition = Transition<Int, Int> { event ->
    delegate(AddTransition(), event)
}
```
- combine multiple transitions in-order
```kotlin
val transition = Transition<Int, Int> { event ->
    transition(state + 1).andThen(LogStateChange())
}
```