### PR TITLE
[Bugfix] Fix double key decoration. 

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -24,7 +24,7 @@ abstract class FormulaContext<State> internal constructor(
         transition: Transition<State, Event>,
     ): Listener<Event> {
         return eventListener(
-            key = transition::class,
+            key = transition.type(),
             transition = transition
         )
     }
@@ -39,7 +39,7 @@ abstract class FormulaContext<State> internal constructor(
         transition: Transition<State, Event>,
     ): Listener<Event> {
         return eventListener(
-            key = JoinedKey(key, transition::class),
+            key = JoinedKey(key, transition.type()),
             transition = transition
         )
     }

--- a/formula/src/main/java/com/instacart/formula/StreamBuilder.kt
+++ b/formula/src/main/java/com/instacart/formula/StreamBuilder.kt
@@ -72,7 +72,7 @@ class StreamBuilder<State> internal constructor(
         stream: Stream<Event>,
         transition: Transition<State, Event>,
     ): BoundStream<Event> {
-        val key = JoinedKey(stream.key(), transition::class)
+        val key = JoinedKey(stream.key(), transition.type())
         val listener = formulaContext.eventListener(key, transition)
         return BoundStream(
             key = key,

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -63,4 +63,11 @@ fun interface Transition<State, in Event> {
      * as part of this event.
      */
     fun TransitionContext<State>.toResult(event: Event): Result<State>
+
+    /**
+     * Transition type is used as part of the key to distinguish different transitions.
+     */
+    fun type(): Any {
+        return this::class
+    }
 }


### PR DESCRIPTION
## What
When `onEvent` was called from `StreamBuilder` it would create a double nested key:
```kotlin
JoinedKey(type, JoinedKey(Unit, type))
```

To avoid this, I've created an internal `eventListener` function.