### PR TITLE
Adding Input to FormulaContext type.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/internal/Binding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/Binding.kt
@@ -59,5 +59,5 @@ internal abstract class Binding<in ParentComponent> {
     /**
      * Listens for active key changes and triggers [Input.onStateChanged] events.
      */
-    internal abstract fun bind(context: FormulaContext<*>, input: Input<ParentComponent>)
+    internal abstract fun bind(context: FormulaContext<*, *>, input: Input<ParentComponent>)
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
@@ -78,7 +78,7 @@ internal class CompositeBinding<ParentComponent, ScopedComponent>(
         return false
     }
 
-    override fun bind(context: FormulaContext<*>, input: Input<ParentComponent>) {
+    override fun bind(context: FormulaContext<*, *>, input: Input<ParentComponent>) {
         context.child(formula, input)
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -56,7 +56,7 @@ internal class FeatureBinding<in Component, in Dependencies, in Key : FragmentKe
         return type.isInstance(key)
     }
 
-    override fun bind(context: FormulaContext<*>, input: Input<Component>) {
+    override fun bind(context: FormulaContext<*, *>, input: Input<Component>) {
         context.child(formula, input)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/Snapshot.kt
+++ b/formula/src/main/java/com/instacart/formula/Snapshot.kt
@@ -22,5 +22,5 @@ interface Snapshot<out Input, State> {
      * Context is a short-lived object associated with the current evaluation. It should not be
      * used after evaluation has finished.
      */
-    val context: FormulaContext<State>
+    val context: FormulaContext<Input, State>
 }

--- a/formula/src/main/java/com/instacart/formula/StreamBuilder.kt
+++ b/formula/src/main/java/com/instacart/formula/StreamBuilder.kt
@@ -8,8 +8,8 @@ import com.instacart.formula.internal.JoinedKey
  * the process and use [events] or [onEvent] to provide a [Transition]
  * which will be called when stream emits an event/
  */
-class StreamBuilder<State> internal constructor(
-    private val formulaContext: FormulaContext<State>,
+class StreamBuilder<out Input, State> internal constructor(
+    private val formulaContext: FormulaContext<Input, State>,
 ) {
     internal val updates = mutableListOf<BoundStream<*>>()
 
@@ -21,7 +21,7 @@ class StreamBuilder<State> internal constructor(
      */
     fun <Event> events(
         stream: Stream<Event>,
-        transition: Transition<State, Event>,
+        transition: Transition<Input, State, Event>,
     ) {
         add(createConnection(stream, transition))
     }
@@ -35,7 +35,7 @@ class StreamBuilder<State> internal constructor(
     fun <Event> onEvent(
         stream: Stream<Event>,
         avoidParameterClash: Any = this,
-        transition: Transition<State, Event>,
+        transition: Transition<Input, State, Event>,
     ) {
         add(createConnection(stream, transition))
     }
@@ -54,7 +54,7 @@ class StreamBuilder<State> internal constructor(
      * ```
      */
     fun <Event> Stream<Event>.onEvent(
-        transition: Transition<State, Event>,
+        transition: Transition<Input, State, Event>,
     ) {
         val stream = this
         this@StreamBuilder.events(stream, transition)
@@ -70,7 +70,7 @@ class StreamBuilder<State> internal constructor(
 
     @PublishedApi internal fun <Event> createConnection(
         stream: Stream<Event>,
-        transition: Transition<State, Event>,
+        transition: Transition<Input, State, Event>,
     ): BoundStream<Event> {
         val key = JoinedKey(stream.key(), transition.type())
         val listener = formulaContext.eventListener(key, transition)

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -7,7 +7,7 @@ package com.instacart.formula
  * which will be executed by the [FormulaRuntime]. If there was a state change, effects function
  * will be executed after [Formula.evaluate] is called.
  */
-fun interface Transition<State, in Event> {
+fun interface Transition<in Input, State, in Event> {
 
     /**
      * Result is an object returned by [Transition.toResult] which indicates what
@@ -62,7 +62,7 @@ fun interface Transition<State, in Event> {
      * change and/or some executable effects. Use [TransitionContext.none] if nothing should happen
      * as part of this event.
      */
-    fun TransitionContext<State>.toResult(event: Event): Result<State>
+    fun TransitionContext<Input, State>.toResult(event: Event): Result<State>
 
     /**
      * Transition type is used as part of the key to distinguish different transitions.

--- a/formula/src/main/java/com/instacart/formula/internal/DelegateTransitionContext.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/DelegateTransitionContext.kt
@@ -2,4 +2,7 @@ package com.instacart.formula.internal
 
 import com.instacart.formula.TransitionContext
 
-internal class DelegateTransitionContext<State>(override val state: State): TransitionContext<State>
+internal class DelegateTransitionContext<Input, State>(
+    override val input: Input,
+    override val state: State,
+): TransitionContext<Input, State>

--- a/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
@@ -10,7 +10,7 @@ import com.instacart.formula.Transition
 internal class ListenerImpl<Input, State, Event>(internal var key: Any) : Listener<Event> {
 
     internal var transitionDispatcher: TransitionDispatcher<Input, State>? = null
-    internal var transition: Transition<State, Event>? = null
+    internal var transition: Transition<Input, State, Event>? = null
 
     override fun invoke(event: Event) {
         transitionDispatcher?.let { dispatcher ->

--- a/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
@@ -7,16 +7,16 @@ import com.instacart.formula.Snapshot
 import com.instacart.formula.StreamBuilder
 import java.lang.IllegalStateException
 
-class SnapshotImpl<Input, State> internal constructor(
+class SnapshotImpl<out Input, State> internal constructor(
     private val transitionId: TransitionId,
     listeners: ScopedListeners,
     private val delegate: Delegate,
     transitionDispatcher: TransitionDispatcher<Input, State>
-) : FormulaContext<State>(listeners, transitionDispatcher), Snapshot<Input, State> {
+) : FormulaContext<Input, State>(listeners, transitionDispatcher), Snapshot<Input, State> {
 
     override val input: Input = transitionDispatcher.input
     override val state: State = transitionDispatcher.state
-    override val context: FormulaContext<State> = this
+    override val context: FormulaContext<Input, State> = this
 
     interface Delegate {
         fun <ChildInput, ChildOutput> child(
@@ -26,7 +26,7 @@ class SnapshotImpl<Input, State> internal constructor(
         ): ChildOutput
     }
 
-    override fun updates(init: StreamBuilder<State>.() -> Unit): List<BoundStream<*>> {
+    override fun updates(init: StreamBuilder<Input, State>.() -> Unit): List<BoundStream<*>> {
         ensureNotRunning()
         val builder = StreamBuilder(this)
         builder.init()

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionDispatcher.kt
@@ -4,11 +4,11 @@ import com.instacart.formula.Transition
 import com.instacart.formula.TransitionContext
 
 internal class TransitionDispatcher<out Input, State>(
-    val input: Input,
+    override val input: Input,
     override val state: State,
     private val handleTransition: (Transition.Result<State>) -> Unit,
     var transitionId: TransitionId
-) : TransitionContext<State> {
+) : TransitionContext<Input, State> {
     var running = false
     var terminated = false
 
@@ -30,7 +30,7 @@ internal class TransitionDispatcher<out Input, State>(
     }
 
     fun <Event> dispatch(
-        transition: Transition<State, Event>,
+        transition: Transition<Input, State, Event>,
         event: Event
     ) {
         val result = transition.toResult(this, event)
@@ -39,8 +39,8 @@ internal class TransitionDispatcher<out Input, State>(
 }
 
 
-internal fun <State, Event> Transition<State, Event>.toResult(
-    context: TransitionContext<State>,
+internal fun <Input, State, Event> Transition<Input, State, Event>.toResult(
+    context: TransitionContext<Input, State>,
     event: Event
 ): Transition.Result<State> {
     return context.run { toResult(event) }

--- a/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/TransitionUtils.kt
@@ -13,7 +13,7 @@ internal object TransitionUtils {
 /**
  * Combines only effects transition result with another transition result.
  */
-internal fun <State> TransitionContext<State>.combine(
+internal fun <State> TransitionContext<*, State>.combine(
     result: Transition.Result.OnlyEffects,
     other: Transition.Result<State>
 ): Transition.Result<State> {
@@ -39,7 +39,7 @@ internal fun <State> TransitionContext<State>.combine(
 /**
  * Combines stateful result with the result of another transition.
  */
-internal fun <State> TransitionContext<State>.combine(
+internal fun <State> TransitionContext<*, State>.combine(
     result: Transition.Result.Stateful<State>,
     other: Transition.Result<State>
 ): Transition.Result<State> {

--- a/formula/src/test/java/com/instacart/formula/subjects/HasChildFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/HasChildFormula.kt
@@ -8,7 +8,7 @@ import com.instacart.formula.Snapshot
 
 class HasChildFormula<ChildInput, ChildOutput>(
     private val child: IFormula<ChildInput, ChildOutput>,
-    private val createChildInput: FormulaContext<Int>.(Int) -> ChildInput
+    private val createChildInput: FormulaContext<*, Int>.(Int) -> ChildInput
 ) : Formula<Unit, Int, HasChildFormula.Output<ChildOutput>>() {
     companion object {
         operator fun <ChildOutput> invoke(

--- a/formula/src/test/java/com/instacart/formula/subjects/OnlyUpdateFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OnlyUpdateFormula.kt
@@ -6,7 +6,7 @@ import com.instacart.formula.StatelessFormula
 import com.instacart.formula.StreamBuilder
 
 class OnlyUpdateFormula<Input>(
-    private val build: StreamBuilder<Unit>.(Input) -> Unit
+    private val build: StreamBuilder<*, Unit>.(Input) -> Unit
 ) : StatelessFormula<Input, Unit>() {
 
     override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {

--- a/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
@@ -9,7 +9,7 @@ import com.instacart.formula.Snapshot
 
 class OptionalChildFormula<ChildInput, ChildOutput>(
     private val child: IFormula<ChildInput, ChildOutput>,
-    private val childInput: FormulaContext<State>.(State) -> ChildInput
+    private val childInput: FormulaContext<*, State>.(State) -> ChildInput
 ): Formula<Unit, OptionalChildFormula.State, OptionalChildFormula.Output<ChildOutput>>() {
     companion object {
         operator fun <ChildOutput> invoke(child: IFormula<Unit, ChildOutput>) = run {

--- a/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
@@ -45,8 +45,8 @@ class StartStopFormula(runtime: TestableRuntime) : Formula<Unit, State, Output>(
         )
     }
 
-    private class UpdateListenFlag(val listen: Boolean): Transition<State, Unit> {
-        override fun TransitionContext<State>.toResult(event: Unit): Transition.Result<State> {
+    private class UpdateListenFlag(val listen: Boolean): Transition<Any, State, Unit> {
+        override fun TransitionContext<Any, State>.toResult(event: Unit): Transition.Result<State> {
             return transition(state.copy(listenForEvents = listen))
         }
     }

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFormula.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFormula.kt
@@ -2,7 +2,6 @@ package com.instacart.formula.compose.stopwatch
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
-import com.instacart.formula.FormulaContext
 import com.instacart.formula.Snapshot
 import com.instacart.formula.rxjava3.RxStream
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -25,8 +24,8 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         return Evaluation(
             output = StopwatchRenderModel(
                 timePassed = formatTimePassed(state.timePassedInMillis),
-                startStopButton = startStopButton(state, context),
-                resetButton = resetButton(state, context)
+                startStopButton = startStopButton(),
+                resetButton = resetButton()
             ),
             updates = context.updates {
                 if (state.isRunning) {
@@ -65,7 +64,7 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         }
     }
 
-    private fun startStopButton(state: State, context: FormulaContext<State>): ButtonRenderModel {
+    private fun Snapshot<*, State>.startStopButton(): ButtonRenderModel {
         return ButtonRenderModel(
             text = when {
                 state.isRunning -> "Stop"
@@ -78,7 +77,7 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         )
     }
 
-    private fun resetButton(state: State, context: FormulaContext<State>): ButtonRenderModel {
+    private fun Snapshot<*, State>.resetButton(): ButtonRenderModel {
         return ButtonRenderModel(
             text = "Reset",
             onSelected = context.onEvent {

--- a/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchFormula.kt
+++ b/samples/stopwatch/src/main/java/com/instacart/formula/stopwatch/StopwatchFormula.kt
@@ -2,7 +2,6 @@ package com.instacart.formula.stopwatch
 
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
-import com.instacart.formula.FormulaContext
 import com.instacart.formula.Snapshot
 import com.instacart.formula.rxjava3.RxStream
 import io.reactivex.rxjava3.android.schedulers.AndroidSchedulers
@@ -27,8 +26,8 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         return Evaluation(
             output = StopwatchRenderModel(
                 timePassed = formatTimePassed(state.timePassedInMillis),
-                startStopButton = startStopButton(state, context),
-                resetButton = resetButton(state, context)
+                startStopButton = startStopButton(),
+                resetButton = resetButton()
             ),
             updates = context.updates {
                 if (state.isRunning) {
@@ -67,7 +66,7 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         }
     }
 
-    private fun startStopButton(state: State, context: FormulaContext<State>): ButtonRenderModel {
+    private fun Snapshot<*, State>.startStopButton(): ButtonRenderModel {
         return ButtonRenderModel(
             text = when {
                 state.isRunning -> "Stop"
@@ -82,7 +81,7 @@ class StopwatchFormula : Formula<Unit, StopwatchFormula.State, StopwatchRenderMo
         )
     }
 
-    private fun resetButton(state: State, context: FormulaContext<State>): ButtonRenderModel {
+    private fun Snapshot<*, State>.resetButton(): ButtonRenderModel {
         return ButtonRenderModel(
             text = "Reset",
             onSelected = context.onEvent {


### PR DESCRIPTION
## What
We are currently automatically propagating `State` to the `Transition.toResult` via `TransitionContext`. We also want to automatically propagate the `Input` type which requires adding another generic parameter to `FormulaContext`.