### PR TITLE
[Formula Android] Fix view factory null pointer.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
+++ b/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
@@ -11,6 +11,7 @@ import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.internal.ActivityStoreFactory
 import com.instacart.formula.android.internal.AppManager
 import com.instacart.formula.android.FragmentKey
+import com.instacart.formula.android.internal.FormulaFragmentDelegate
 import java.lang.IllegalStateException
 
 object FormulaAndroid {
@@ -42,6 +43,8 @@ object FormulaAndroid {
 
         this.application = application
         this.appManager = appManager
+        FormulaFragmentDelegate.appManager = appManager
+        FormulaFragmentDelegate.fragmentEnvironment = fragmentEnvironment
     }
 
     /**

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -5,6 +5,8 @@ import androidx.lifecycle.Lifecycle
 import com.instacart.formula.android.events.ActivityResult
 import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.ActivityStore
+import com.instacart.formula.android.FormulaFragment
+import com.instacart.formula.android.ViewFactory
 import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 
@@ -105,6 +107,10 @@ internal class ActivityManager<Activity : FragmentActivity>(
 
     fun dispose() {
         stateSubscription.dispose()
+    }
+
+    fun viewFactory(fragment: FormulaFragment): ViewFactory<Any>? {
+        return fragmentRenderView?.viewFactory(fragment)
     }
 
     private fun callOnPreCreateException(activity: FragmentActivity): IllegalStateException {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AppManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AppManager.kt
@@ -115,7 +115,7 @@ internal class AppManager(
         return findStore(activity)?.onBackPressed() ?: false
     }
 
-    private fun findStore(activity: FragmentActivity): ActivityManager<FragmentActivity>? {
+    fun findStore(activity: FragmentActivity): ActivityManager<FragmentActivity>? {
         val key = activityToKeyMap[activity]
         return key?.let { componentMap[it] }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
@@ -1,0 +1,42 @@
+package com.instacart.formula.android.internal
+
+import com.instacart.formula.android.FormulaFragment
+import com.instacart.formula.android.FragmentEnvironment
+import com.instacart.formula.android.FragmentKey
+import com.instacart.formula.android.ViewFactory
+
+internal object FormulaFragmentDelegate {
+    var appManager: AppManager? = null
+    var fragmentEnvironment: FragmentEnvironment? = null
+
+    fun viewFactory(fragment: FormulaFragment): ViewFactory<Any>? {
+        val appManager = appManager ?: throw IllegalStateException("FormulaAndroid.init() not called.")
+
+        val activity = fragment.activity ?: run {
+            fragmentEnvironment().logger("FormulaFragment has no activity attached: ${fragment.getFragmentKey()}")
+            return null
+        }
+
+        val viewFactory = appManager.findStore(activity)?.viewFactory(fragment) ?: run {
+            // Log view factory is missing
+            if (activity.isDestroyed) {
+                fragmentEnvironment().logger("Missing formula fragment view factory because activity is destroyed")
+            } else {
+                val error = IllegalStateException("Formula with ${fragment.getFragmentKey()} is missing view factory.")
+                fragmentEnvironment().onScreenError(fragment.getFragmentKey(), error)
+            }
+
+            return null
+        }
+        return viewFactory
+    }
+
+
+    fun logFragmentError(key: FragmentKey, error: Throwable) {
+        fragmentEnvironment().onScreenError(key, error)
+    }
+
+    private fun fragmentEnvironment(): FragmentEnvironment {
+        return fragmentEnvironment ?: throw IllegalStateException("FormulaAndroid.init() not called.")
+    }
+}

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
@@ -10,7 +10,7 @@ internal object FormulaFragmentDelegate {
     var fragmentEnvironment: FragmentEnvironment? = null
 
     fun viewFactory(fragment: FormulaFragment): ViewFactory<Any>? {
-        val appManager = appManager ?: throw IllegalStateException("FormulaAndroid.init() not called.")
+        val appManager = checkNotNull(appManager) { "FormulaAndroid.init() not called." }
 
         val activity = fragment.activity ?: run {
             fragmentEnvironment().logger("FormulaFragment has no activity attached: ${fragment.getFragmentKey()}")
@@ -20,7 +20,7 @@ internal object FormulaFragmentDelegate {
         val viewFactory = appManager.findStore(activity)?.viewFactory(fragment) ?: run {
             // Log view factory is missing
             if (activity.isDestroyed) {
-                fragmentEnvironment().logger("Missing formula fragment view factory because activity is destroyed")
+                fragmentEnvironment().logger("Missing view factory because activity is destroyed: ${fragment.getFragmentKey()}")
             } else {
                 val error = IllegalStateException("Formula with ${fragment.getFragmentKey()} is missing view factory.")
                 fragmentEnvironment().onScreenError(fragment.getFragmentKey(), error)
@@ -37,6 +37,6 @@ internal object FormulaFragmentDelegate {
     }
 
     private fun fragmentEnvironment(): FragmentEnvironment {
-        return fragmentEnvironment ?: throw IllegalStateException("FormulaAndroid.init() not called.")
+        return checkNotNull(fragmentEnvironment) { "FormulaAndroid.init() not called." }
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -17,6 +17,7 @@ import com.instacart.formula.android.events.FragmentLifecycleEvent
 import com.instacart.formula.android.BackCallback
 import com.instacart.formula.android.FeatureEvent
 import com.instacart.formula.android.FragmentId
+import com.instacart.formula.android.ViewFactory
 import java.util.LinkedList
 import java.util.UUID
 
@@ -96,11 +97,6 @@ internal class FragmentFlowRenderView(
             super.onFragmentAttached(fm, f, context)
             initializeFragmentInstanceIdIfNeeded(f)
 
-            if (f is FormulaFragment) {
-                f.fragmentEnvironment = fragmentEnvironment
-                f.viewFactory = FormulaFragmentViewFactory(f.getFormulaFragmentId(), featureProvider)
-            }
-
             if (FragmentLifecycle.shouldTrack(f)) {
                 onLifecycleEvent(FragmentLifecycle.createAddedEvent(f))
             } else {
@@ -142,6 +138,11 @@ internal class FragmentFlowRenderView(
      */
     fun dispose() {
         activity.supportFragmentManager.unregisterFragmentLifecycleCallbacks(callback)
+    }
+
+    fun viewFactory(fragment: FormulaFragment): ViewFactory<Any> {
+        initializeFragmentInstanceIdIfNeeded(fragment)
+        return FormulaFragmentViewFactory(fragment.getFormulaFragmentId(), featureProvider)
     }
 
     private fun notifyLifecycleStateChanged(fragment: Fragment, newState: Lifecycle.State) {


### PR DESCRIPTION
## What
It seems that on activity is destroyed event, it can still try to initialize a fragment view. Previously we were crashing because we didn't have view factory set, but now we will just return null view and log this.
