### PR TITLE
Event non nullability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Changelog
 ## [0.8.0] - TBD
+- **Breaking**: selectActivityEvents now explicitly requires a non-null type
 
 ## [0.7.1] - June 28, 2022
 - **Breaking**: Rename `FragmentBindingBuilder` to `FragmentStoreBuilder`

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
@@ -60,7 +60,7 @@ abstract class ActivityStoreContext<out Activity : FragmentActivity> {
      *
      * @param Event Type of event
      */
-    abstract fun <Event> selectActivityEvents(
+    abstract fun <Event : Any> selectActivityEvents(
         select: Activity.() -> Observable<Event>
     ): Observable<Event>
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -55,7 +55,7 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
         return isFragmentResumed(key.tag)
     }
 
-    override fun <Event> selectActivityEvents(
+    override fun <Event : Any> selectActivityEvents(
         select: Activity.() -> Observable<Event>
     ): Observable<Event> {
         // TODO: should probably use startedActivity


### PR DESCRIPTION
explicitly make Event non-nullable as it is massaged into an `observable<Event>`
This becomes important with kotlin 1.8 as it applies stricter type checks