### PR TITLE
Enable formula input and output validation.

### DIFF
--- a/formula-coroutines/src/main/java/com/instacart/formula/coroutines/FlowRuntimeExtensions.kt
+++ b/formula-coroutines/src/main/java/com/instacart/formula/coroutines/FlowRuntimeExtensions.kt
@@ -16,7 +16,8 @@ fun <Input : Any, Output : Any> IFormula<Input, Output>.toFlow(
 }
 
 fun <Input : Any, Output : Any> IFormula<Input, Output>.toFlow(
-    input: Flow<Input>
+    input: Flow<Input>,
+    isValidationEnabled: Boolean = false,
 ): Flow<Output> {
-    return FlowRuntime.start(input = input, formula = this)
+    return FlowRuntime.start(input = input, formula = this, isValidationEnabled = isValidationEnabled)
 }

--- a/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxJavaRuntimeExtensions.kt
+++ b/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxJavaRuntimeExtensions.kt
@@ -14,7 +14,8 @@ fun <Input : Any, Output : Any> IFormula<Input, Output>.toObservable(
 }
 
 fun <Input : Any, Output : Any> IFormula<Input, Output>.toObservable(
-    input: Observable<Input>
+    input: Observable<Input>,
+    isValidationEnabled: Boolean = false,
 ): Observable<Output> {
-    return RxJavaRuntime.start(input = input, formula = this)
+    return RxJavaRuntime.start(input = input, formula = this, isValidationEnabled = isValidationEnabled)
 }

--- a/formula-test/src/main/java/com/instacart/formula/test/RxJavaFormulaTestDelegate.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/RxJavaFormulaTestDelegate.kt
@@ -8,11 +8,12 @@ import io.reactivex.rxjava3.subjects.BehaviorSubject
  * Binds [formula] to RxJava3 runtime.
  */
 class RxJavaFormulaTestDelegate<Input : Any, Output : Any, FormulaT : IFormula<Input, Output>>(
-    override val formula: FormulaT
+    override val formula: FormulaT,
+    private val isValidationEnabled: Boolean = true,
 ) : FormulaTestDelegate<Input, Output, FormulaT> {
     private val inputRelay = BehaviorSubject.create<Input>()
     private val observer = formula
-        .toObservable(inputRelay)
+        .toObservable(inputRelay, isValidationEnabled = isValidationEnabled)
         .test()
 
     override fun values(): List<Output> {

--- a/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
@@ -8,8 +8,10 @@ import com.instacart.formula.IFormula
  *
  * Note: Formula won't start until you pass it an [input][TestFormulaObserver.input].
  */
-fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(): TestFormulaObserver<Input, Output, F> {
-    return TestFormulaObserver(RxJavaFormulaTestDelegate(this))
+fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
+    isValidationEnabled: Boolean = true,
+): TestFormulaObserver<Input, Output, F> {
+    return TestFormulaObserver(RxJavaFormulaTestDelegate(this, isValidationEnabled))
 }
 
 /**

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -5,6 +5,12 @@ import com.instacart.formula.Formula
 
 interface FormulaManager<Input, Output> {
     /**
+     * Sets validation mode before running an identical evaluation to verify that
+     * inputs and outputs do not change.
+     */
+    fun setValidationRun(isValidationEnabled: Boolean)
+
+    /**
      * Creates the current [Output] and prepares the next frame that will need to be processed.
      */
     fun evaluate(

--- a/formula/src/main/java/com/instacart/formula/internal/ValidationException.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ValidationException.kt
@@ -1,0 +1,3 @@
+package com.instacart.formula.internal
+
+class ValidationException(message: String) : RuntimeException(message)

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -175,7 +175,7 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
             .apply { formula.incrementEvents.triggerEvent() }
             .apply { formula.incrementEvents.triggerEvent() }
             .apply {
-                val expected = listOf(0, 0, 1, 2, 3)
+                val expected = listOf(0, 1, 2, 3)
                 assertThat(values().map { it.state }).isEqualTo(expected)
             }
     }
@@ -189,7 +189,7 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
             .apply { formula.incrementEvents.triggerEvent() }
             .apply { formula.incrementEvents.triggerEvent() }
             .apply {
-                val expected = listOf(0, 0, 1, 1)
+                val expected = listOf(0, 1)
                 assertThat(values().map { it.state }).isEqualTo(expected)
             }
     }

--- a/formula/src/test/java/com/instacart/formula/subjects/ChildMessageTriggersEventTransitionInParent.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ChildMessageTriggersEventTransitionInParent.kt
@@ -26,7 +26,7 @@ object ChildMessageTriggersEventTransitionInParent {
         private val service = Service()
         private val childFormula = SideEffectFormula(service::trigger)
 
-        class RenderModel(
+        data class RenderModel(
             val count: Int,
             val child: SideEffectFormula.Output
         )

--- a/formula/src/test/java/com/instacart/formula/subjects/DuplicateListenerKeysHandledByIndexing.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/DuplicateListenerKeysHandledByIndexing.kt
@@ -10,7 +10,7 @@ object DuplicateListenerKeysHandledByIndexing {
 
     fun test(runtime: TestableRuntime) = runtime.test(TestFormula(), Unit)
 
-    class TestOutput(
+    data class TestOutput(
         val listeners: List<Listener<Unit>>,
     )
 

--- a/formula/src/test/java/com/instacart/formula/subjects/MessageFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/MessageFormula.kt
@@ -9,7 +9,7 @@ class MessageFormula : Formula<MessageFormula.Input, Int, MessageFormula.Output>
 
     data class Input(val messageHandler: (Int) -> Unit)
 
-    class Output(
+    data class Output(
         val state: Int,
         val triggerMessage: Listener<Unit>,
         val incrementAndMessage: Listener<Unit>,

--- a/formula/src/test/java/com/instacart/formula/subjects/MixingCallbackUseWithKeyUse.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/MixingCallbackUseWithKeyUse.kt
@@ -7,7 +7,7 @@ import com.instacart.formula.Snapshot
 
 class MixingCallbackUseWithKeyUse {
 
-    class ParentOutput(
+    data class ParentOutput(
         val firstCallback: Listener<Unit>,
         val secondCallback: Listener<Unit>,
         val thirdCallback: Listener<Unit>,

--- a/formula/src/test/java/com/instacart/formula/subjects/NestedKeyFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/NestedKeyFormula.kt
@@ -7,7 +7,7 @@ import com.instacart.formula.Snapshot
 
 class NestedKeyFormula : Formula<Unit, Unit, NestedKeyFormula.Output>() {
 
-    class Output(val callback: Listener<Unit>)
+    data class Output(val callback: Listener<Unit>)
 
     override fun initialState(input: Unit) = Unit
 

--- a/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/OptionalChildFormula.kt
@@ -21,7 +21,7 @@ class OptionalChildFormula<ChildInput, ChildOutput>(
         val showChild: Boolean = true
     )
 
-    class Output<ChildOutput>(
+    data class Output<ChildOutput>(
         val child: ChildOutput?,
         val toggleChild: Listener<Unit>,
     )

--- a/formula/src/test/java/com/instacart/formula/subjects/ReusableFunctionCreatesUniqueListeners.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ReusableFunctionCreatesUniqueListeners.kt
@@ -10,7 +10,7 @@ object ReusableFunctionCreatesUniqueListeners {
 
     fun test(runtime: TestableRuntime) = runtime.test(TestFormula(), Unit)
 
-    class TestOutput(
+    data class TestOutput(
         val firstListener: Listener<Unit>,
         val secondListener: Listener<Unit>,
     )

--- a/formula/src/test/java/com/instacart/formula/subjects/SideEffectFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/SideEffectFormula.kt
@@ -9,7 +9,7 @@ class SideEffectFormula(
     private val onSideEffect: () -> Unit
 ) : Formula<Unit, Int, SideEffectFormula.Output>() {
 
-    class Output(
+    data class Output(
         val triggerSideEffect: Listener<Unit>
     )
 

--- a/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
@@ -19,7 +19,7 @@ class StartStopFormula(runtime: TestableRuntime) : Formula<Unit, State, Output>(
         val count: Int = 0
     )
 
-    class Output(
+    data class Output(
         val state: Int,
         val startListening: Listener<Unit>,
         val stopListening: Listener<Unit>,

--- a/formula/src/test/java/com/instacart/formula/subjects/UniqueListenersWithinLoop.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/UniqueListenersWithinLoop.kt
@@ -10,7 +10,7 @@ object UniqueListenersWithinLoop {
 
     fun test(runtime: TestableRuntime) = runtime.test(TestFormula(), Unit)
 
-    class TestOutput(
+    data class TestOutput(
         val listeners: List<Listener<Unit>>,
     )
 

--- a/formula/src/test/java/com/instacart/formula/subjects/UsingKeyToScopeCallbacksWithinAnotherFunction.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/UsingKeyToScopeCallbacksWithinAnotherFunction.kt
@@ -8,11 +8,11 @@ import com.instacart.formula.StatelessFormula
 
 object UsingKeyToScopeCallbacksWithinAnotherFunction {
 
-    class ChildOutput(
+    data class ChildOutput(
         val callback: Listener<Unit>,
     )
 
-    class TestOutput(
+    data class TestOutput(
         val first: ChildOutput,
         val second: ChildOutput
     )

--- a/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
@@ -93,7 +93,7 @@ private class CoroutineTestDelegate<Input : Any, Output : Any, FormulaT : IFormu
     private val errors = mutableListOf<Throwable>()
 
     private val inputFlow = MutableSharedFlow<Input>(1)
-    private val formulaFlow = formula.toFlow(inputFlow)
+    private val formulaFlow = formula.toFlow(inputFlow, isValidationEnabled = true)
         .onEach { values.add(it) }
         .catch { errors.add(it) }
 


### PR DESCRIPTION
## What

I've added a verification/validation mode that enables us to ensure that equality guarantees are fulfilled by formula implementations. This mode will always run `Formula.evaluate` twice and check that the output/input/actions do not change for identical runs.  