### PR TITLE
Change order of updates where each leaf executes first.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -136,15 +136,7 @@ class FormulaRuntime<Input : Any, Output : Any>(
 
             val transitionId = manager.transitionID
             if (!manager.terminated) {
-                if (manager.terminateDetachedChildren()) {
-                    continue
-                }
-
-                if (manager.terminateOldUpdates()) {
-                    continue
-                }
-
-                if (manager.startNewUpdates()) {
+                if (manager.executeUpdates()) {
                     continue
                 }
             }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -16,21 +16,11 @@ interface FormulaManager<Input, Output> {
     fun evaluate(input: Input): Evaluation<Output>
 
     /**
-     * Called after [evaluate] to terminate children that were removed.
+     * Called after [evaluate] to update child formulas and actions.
      *
      * @return True if transition happened while performing this.
      */
-    fun terminateDetachedChildren(): Boolean
-
-    /**
-     * Called after [evaluate] to terminate old streams.
-     */
-    fun terminateOldUpdates(): Boolean
-
-    /**
-     * Called after [evaluate] to start new streams.
-     */
-    fun startNewUpdates(): Boolean
+    fun executeUpdates(): Boolean
 
     /**
      * Called when [Formula] is removed. This is should not trigger any external side-effects,

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -138,38 +138,21 @@ internal class FormulaManagerImpl<Input, State, Output>(
         return result
     }
 
-    override fun terminateDetachedChildren(): Boolean {
-        return childrenManager?.terminateDetachedChildren(transitionID) == true
-    }
-
-    // TODO: should probably terminate children streams, then self.
-    override fun terminateOldUpdates(): Boolean {
+    override fun executeUpdates(): Boolean {
         val transitionID = transitionID
+        if (childrenManager?.executeChildUpdates(transitionID) == true) {
+            return true
+        }
+
+        if (childrenManager?.terminateChildren(transitionID) == true) {
+            return true
+        }
+
         if (actionManager.terminateOld(transitionID)) {
             return true
         }
 
-        // Step through children frames
-        if (childrenManager?.terminateOldUpdates(transitionID) == true) {
-            return true
-        }
-
-        return false
-    }
-
-    override fun startNewUpdates(): Boolean {
-        val transitionID = transitionID
-        // Update parent workers so they are ready to handle events
-        if (actionManager.startNew(transitionID)) {
-            return true
-        }
-
-        // Step through children frames
-        if (childrenManager?.startNewUpdates(transitionID) == true) {
-            return true
-        }
-
-        return false
+        return actionManager.startNew(transitionID)
     }
 
     fun <ChildInput, ChildOutput> child(


### PR DESCRIPTION
The updated order of execution:
- Running child formulas executes updates
    - Execute child formula updates
        - And the cycle continues...
    - Terminate detached child formulas
    - Terminate old actions
    - Start new actions
- Terminate previously detached child formulas
- Terminate old actions
- Start new actions

This allows us to run execute all child formula updates in one go.