### PR TITLE
Use CountingInspector to test evaluations/runs.

### DIFF
--- a/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
@@ -1,0 +1,40 @@
+package com.instacart.formula.test
+
+import com.instacart.formula.Inspector
+import java.lang.AssertionError
+import kotlin.reflect.KClass
+
+class CountingInspector : Inspector {
+    private var runCount = 0
+    private val evaluatedList = mutableListOf<Class<*>>()
+
+    override fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) {
+        if (evaluated) {
+            evaluatedList.add(formulaType.java)
+        }
+    }
+
+    override fun onRunStarted(evaluate: Boolean) {
+        runCount += 1
+    }
+
+    fun assertEvaluationCount(expected: Int) = apply {
+        val evaluationCount = evaluatedList.size
+        if (evaluationCount != expected) {
+            throw AssertionError("Evaluation count does not match - count: $evaluationCount, expected: $expected")
+        }
+    }
+
+    fun assertEvaluationCount(formulaType: KClass<*>, expected: Int) = apply {
+        val evaluationCount = evaluatedList.filter { it == formulaType.java }.size
+        if (evaluationCount != expected) {
+            throw AssertionError("Evaluation count does not match - count: $evaluationCount, expected: $expected, list: $evaluatedList")
+        }
+    }
+
+    fun assertRunCount(expected: Int) = apply {
+        if (runCount != expected) {
+            throw AssertionError("Run count does not match - count: $runCount, expected: $expected")
+        }
+    }
+}

--- a/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
@@ -1,12 +1,16 @@
 package com.instacart.formula.test
 
+import com.instacart.formula.DeferredAction
 import com.instacart.formula.Inspector
+import com.instacart.formula.Transition
 import java.lang.AssertionError
 import kotlin.reflect.KClass
 
 class CountingInspector : Inspector {
     private var runCount = 0
     private val evaluatedList = mutableListOf<Class<*>>()
+    private val actionsStarted = mutableListOf<Class<*>>()
+    private val stateTransitions = mutableListOf<Class<*>>()
 
     override fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) {
         if (evaluated) {
@@ -16,6 +20,20 @@ class CountingInspector : Inspector {
 
     override fun onRunStarted(evaluate: Boolean) {
         runCount += 1
+    }
+
+    override fun onActionStarted(formulaType: KClass<*>, action: DeferredAction<*>) {
+        actionsStarted.add(formulaType.java)
+    }
+
+    override fun onTransition(
+        formulaType: KClass<*>,
+        result: Transition.Result<*>,
+        evaluate: Boolean
+    ) {
+        if (result is Transition.Result.Stateful) {
+            stateTransitions.add(formulaType.java)
+        }
     }
 
     fun assertEvaluationCount(expected: Int) = apply {
@@ -35,6 +53,20 @@ class CountingInspector : Inspector {
     fun assertRunCount(expected: Int) = apply {
         if (runCount != expected) {
             throw AssertionError("Run count does not match - count: $runCount, expected: $expected")
+        }
+    }
+
+    fun assertActionsStarted(expected: Int) = apply {
+        val actionsStartedCount = actionsStarted.size
+        if (actionsStartedCount != expected) {
+            throw AssertionError("Actions started count does not match - count: $actionsStartedCount, expected: $expected")
+        }
+    }
+
+    fun assertStateTransitions(formulaType: KClass<*>, expected: Int) = apply {
+        val stateTransitionCount = stateTransitions.filter { it == formulaType.java }.size
+        if (stateTransitionCount != expected) {
+            throw AssertionError("State transition count does not match - count: $stateTransitionCount, expected: $expected, list: $stateTransitions")
         }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -41,7 +41,7 @@ class FormulaRuntime<Input : Any, Output : Any>(
         this.key = formula.key(input)
 
         if (initialization) {
-            manager = FormulaManagerImpl(this, implementation, input, inspector = inspector)
+            manager = FormulaManagerImpl(this, implementation, input, loggingType = formula::class, inspector = inspector)
             forceRun()
 
             hasInitialFinished = true

--- a/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
@@ -9,7 +9,7 @@ import kotlin.reflect.KClass
  */
 internal class ActionManager(
     private val manager: FormulaManagerImpl<*, *, *>,
-    private val formulaType: KClass<*>,
+    private val loggingType: KClass<*>,
     private val inspector: Inspector?,
 ) {
     companion object {
@@ -74,7 +74,7 @@ internal class ActionManager(
             iterator.remove()
 
             if (!isRunning(action)) {
-                inspector?.onActionStarted(formulaType, action)
+                inspector?.onActionStarted(loggingType, action)
 
                 getOrInitRunningActions().add(action)
                 action.start()
@@ -142,7 +142,7 @@ internal class ActionManager(
     }
 
     private fun finishAction(action: DeferredAction<*>) {
-        inspector?.onActionFinished(formulaType, action)
+        inspector?.onActionFinished(loggingType, action)
         action.tearDown()
         action.listener = NO_OP
     }

--- a/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
@@ -63,7 +63,7 @@ internal class ChildrenManager(
         return children
             .findOrInit(key) {
                 val implementation = formula.implementation()
-                FormulaManagerImpl(delegate, implementation, input, inspector = inspector)
+                FormulaManagerImpl(delegate, implementation, input, loggingType = formula::class, inspector = inspector)
             }
             .requestAccess {
                 "There already is a child with same key: $key. Override [Formula.key] function."

--- a/formula/src/test/java/com/instacart/formula/subjects/ParentTransitionOnChildActionStart.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ParentTransitionOnChildActionStart.kt
@@ -1,47 +1,15 @@
 package com.instacart.formula.subjects
 
-import com.instacart.formula.Action
-import com.instacart.formula.Evaluation
-import com.instacart.formula.Formula
-import com.instacart.formula.Snapshot
-import com.instacart.formula.StatelessFormula
+import com.instacart.formula.types.OnInitActionFormula
 
 object ParentTransitionOnChildActionStart {
 
-    fun formula() = Parent(Child())
-
-    class Parent(val child: Child) : Formula<Unit, Int, Int>() {
-        override fun initialState(input: Unit): Int = 0
-
-        override fun Snapshot<Unit, Int>.evaluate(): Evaluation<Int> {
-            val input = Child.Input(
-                onIncrementState = context.callback {
+    fun formula(eventNumber: Int) = run {
+        val child = OnInitActionFormula(eventNumber)
+        HasChildFormula(child) {
+            OnInitActionFormula.Input(
+                onAction = callback {
                     transition(state + 1)
-                }
-            )
-            context.child(child, input)
-            return Evaluation(
-                output = state,
-            )
-        }
-    }
-
-    class Child : StatelessFormula<Child.Input, Unit>() {
-        data class Input(
-            val onIncrementState: () -> Unit,
-        )
-
-        override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {
-            return Evaluation(
-                output = Unit,
-                actions = context.actions {
-                    Action.onInit().onEvent {
-                        transition {
-                            input.onIncrementState()
-                            input.onIncrementState()
-                            input.onIncrementState()
-                        }
-                    }
                 }
             )
         }

--- a/formula/src/test/java/com/instacart/formula/subjects/ParentTransitionOnChildActionStart.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ParentTransitionOnChildActionStart.kt
@@ -1,0 +1,49 @@
+package com.instacart.formula.subjects
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.StatelessFormula
+
+object ParentTransitionOnChildActionStart {
+
+    fun formula() = Parent(Child())
+
+    class Parent(val child: Child) : Formula<Unit, Int, Int>() {
+        override fun initialState(input: Unit): Int = 0
+
+        override fun Snapshot<Unit, Int>.evaluate(): Evaluation<Int> {
+            val input = Child.Input(
+                onIncrementState = context.callback {
+                    transition(state + 1)
+                }
+            )
+            context.child(child, input)
+            return Evaluation(
+                output = state,
+            )
+        }
+    }
+
+    class Child : StatelessFormula<Child.Input, Unit>() {
+        data class Input(
+            val onIncrementState: () -> Unit,
+        )
+
+        override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {
+            return Evaluation(
+                output = Unit,
+                actions = context.actions {
+                    Action.onInit().onEvent {
+                        transition {
+                            input.onIncrementState()
+                            input.onIncrementState()
+                            input.onIncrementState()
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/subjects/StreamInputFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StreamInputFormula.kt
@@ -1,21 +1,28 @@
 package com.instacart.formula.subjects
 
-import com.instacart.formula.Action
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Snapshot
 import com.instacart.formula.StatelessFormula
+import com.instacart.formula.types.OnDataActionFormula
 
 class StreamInputFormula : StatelessFormula<Int, Unit>()  {
     val messages = mutableListOf<Int>()
 
+    private val onDataActionFormula = OnDataActionFormula()
+
     override fun Snapshot<Int, Unit>.evaluate(): Evaluation<Unit> {
-        return Evaluation(
-            output = Unit,
-            actions = context.actions {
-                Action.onData(input).onEvent {
-                    transition { messages.add(it) }
+        context.child(
+            formula = onDataActionFormula,
+            input = OnDataActionFormula.Input(
+                data = input,
+                onData = context.onEvent {
+                    transition {
+                        messages.add(it)
+                    }
                 }
-            }
+            )
         )
+
+        return Evaluation(output = Unit)
     }
 }

--- a/formula/src/test/java/com/instacart/formula/types/IncrementFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/IncrementFormula.kt
@@ -1,0 +1,32 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+
+/**
+ * Formula with an output that contains current integer state and an event listener that
+ * increments the integer state.
+ */
+class IncrementFormula: Formula<Unit, Int, IncrementFormula.Output>() {
+
+    data class Output(
+        val value: Int,
+        val onIncrement: () -> Unit,
+    )
+
+    override fun initialState(input: Unit): Int {
+        return 0
+    }
+
+    override fun Snapshot<Unit, Int>.evaluate(): Evaluation<Output> {
+        return Evaluation(
+            output = Output(
+                value = state,
+                onIncrement = context.callback {
+                    transition(state + 1)
+                },
+            )
+        )
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/types/OnDataActionFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/OnDataActionFormula.kt
@@ -1,0 +1,29 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Snapshot
+import com.instacart.formula.StatelessFormula
+
+/**
+ * On data formula starts an action from [Input.data] and invokes a parent listener
+ * on each data change.
+ */
+class OnDataActionFormula : StatelessFormula<OnDataActionFormula.Input, Unit>() {
+
+    data class Input(
+        val data: Int,
+        val onData: (Int) -> Unit,
+    )
+
+    override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {
+        return Evaluation(
+            output = Unit,
+            actions = context.actions {
+                Action.onData(input.data).onEvent {
+                    transition { input.onData(it) }
+                }
+            }
+        )
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/types/OnInitActionFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/OnInitActionFormula.kt
@@ -1,0 +1,31 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Snapshot
+import com.instacart.formula.StatelessFormula
+
+/**
+ * On init starts an action which emits a transition that calls a parent listener.
+ */
+class OnInitActionFormula(private val eventNumber: Int) : StatelessFormula<OnInitActionFormula.Input, Unit>() {
+
+    data class Input(
+        val onAction: () -> Unit,
+    )
+
+    override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {
+        return Evaluation(
+            output = Unit,
+            actions = context.actions {
+                Action.onInit().onEvent {
+                    transition {
+                        (0 until eventNumber).forEach {
+                            input.onAction()
+                        }
+                    }
+                }
+            }
+        )
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/types/OnStartActionFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/OnStartActionFormula.kt
@@ -1,0 +1,36 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Snapshot
+import com.instacart.formula.StatelessFormula
+import com.instacart.formula.rxjava3.RxAction
+import io.reactivex.rxjava3.core.Observable
+
+/**
+ * On first evaluate starts an action which calls a listener.
+ */
+class OnStartActionFormula(
+    private val eventNumber: Int,
+) : StatelessFormula<OnStartActionFormula.Input, Unit>() {
+
+    data class Input(
+        val onAction: () -> Unit,
+    )
+
+    override fun Snapshot<Input, Unit>.evaluate(): Evaluation<Unit> {
+        return Evaluation(
+            output = Unit,
+            actions = context.actions {
+                RxAction.fromObservable {
+                    val events = 0 until eventNumber
+                    for (event in events) {
+                        input.onAction()
+                    }
+                    Observable.empty()
+                }.onEvent {
+                    none()
+                }
+            }
+        )
+    }
+}


### PR DESCRIPTION
## What
- Pass the actual Formula and not the IFormula::implementation. If use just the implementation we get a lot of opage StatelessFormula, ActionFormula, etc (taken from https://github.com/instacart/formula/pull/307)
- Added `CountingInspector` to assert to evaluations
- Updated tests to check for evaluation events.