### PR TITLE
[Bugfix] Fix old listener crash.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -279,6 +279,10 @@ internal class FormulaManagerImpl<Input, State, Output>(
      * @return True if we need to re-evaluate.
      */
     private fun postEvaluation(evaluationId: Long): Boolean {
+        if (isEvaluationNeeded(evaluationId)) {
+            return true
+        }
+
         if (handleTransitionQueue(evaluationId)) {
             return true
         }

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -26,7 +26,7 @@ import com.instacart.formula.subjects.EventFormula
 import com.instacart.formula.subjects.ExtremelyNestedFormula
 import com.instacart.formula.subjects.FromObservableWithInputFormula
 import com.instacart.formula.subjects.HasChildFormula
-import com.instacart.formula.subjects.IndirectNestedCallbackCallRobot
+import com.instacart.formula.subjects.MultiChildIndirectStateChangeRobot
 import com.instacart.formula.subjects.InputChangeWhileFormulaRunningRobot
 import com.instacart.formula.subjects.KeyUsingListFormula
 import com.instacart.formula.subjects.MessageFormula
@@ -696,7 +696,7 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
 
     @Test
     fun `formula calls own event listener which starts multiple transitions`() {
-        val robot = IndirectNestedCallbackCallRobot(runtime)
+        val robot = MultiChildIndirectStateChangeRobot(runtime)
         robot.start()
         robot.subject.output { onAction() }
         robot.subject.output {

--- a/formula/src/test/java/com/instacart/formula/subjects/IndirectNestedCallbackCallRobot.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/IndirectNestedCallbackCallRobot.kt
@@ -1,0 +1,107 @@
+package com.instacart.formula.subjects
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.rxjava3.RxAction
+import com.instacart.formula.test.TestableRuntime
+import com.instacart.formula.types.IncrementFormula
+import io.reactivex.rxjava3.core.Observable
+
+class IndirectNestedCallbackCallRobot(runtime: TestableRuntime) {
+    val subject = runtime.test(Parent())
+
+    fun start() = apply {
+        subject.input(Unit)
+    }
+
+    class Child : Formula<Unit, Child.State, Child.Output>() {
+        data class State(
+            val actionId: Int = 0,
+            val value: Int = 0,
+        )
+
+        data class Output(
+            val value: Int,
+            val onChildAction: () -> Unit,
+        )
+
+        override fun initialState(input: Unit): State = State()
+
+        override fun Snapshot<Unit, State>.evaluate(): Evaluation<Output> {
+            return Evaluation(
+                output = Output(
+                    value = state.value,
+                    onChildAction = context.callback {
+                        val newState = state.copy(actionId = state.actionId + 1)
+                        transition(newState)
+                    }
+                ),
+                actions = context.actions {
+                    if (state.actionId > 0) {
+                        RxAction.fromObservable(state.actionId) {
+                            // Increment two times
+                            Observable.just(1, 1)
+                        }.onEvent {
+                            val newState = state.copy(value = state.value + it)
+                            transition(newState)
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    class Parent : Formula<Unit, Parent.State, Parent.Output>() {
+        data class State(
+            val actionId: Int = 0,
+            val value: Int = 0,
+        )
+
+        data class Output(
+            val parentValue: Int,
+            val childValue: Int,
+            val onAction: () -> Unit
+        )
+
+        private val incrementFormula = Child()
+
+        override fun initialState(input: Unit): State = State()
+
+        override fun Snapshot<Unit, State>.evaluate(): Evaluation<Output> {
+            val next = context.callback {
+                val newState = state.copy(actionId = state.actionId + 1)
+                transition(newState)
+            }
+
+            val incrementOutput = context.child(incrementFormula)
+
+            return Evaluation(
+                output = Output(
+                    parentValue = state.value,
+                    childValue = incrementOutput.value,
+                    onAction = context.callback {
+                        transition {
+                            next()
+                        }
+                    }
+                ),
+                actions = context.actions {
+                    if (state.actionId > 0) {
+                        RxAction.fromObservable(state.actionId) {
+                            // Call child
+                            incrementOutput.onChildAction()
+
+                            // Emit events
+                            Observable.just(1, 1, 1)
+                        }.onEvent {
+                            val newState = state.copy(value = state.value + it)
+                            transition(newState)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/subjects/NestedCallbackCallRobot.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/NestedCallbackCallRobot.kt
@@ -1,0 +1,39 @@
+package com.instacart.formula.subjects
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.test.TestableRuntime
+
+class NestedCallbackCallRobot(runtime: TestableRuntime) {
+    val subject = runtime.test(Parent())
+
+    fun start() = apply {
+        subject.input(Unit)
+    }
+
+    class Parent : Formula<Unit, Int, Parent.Output>() {
+        data class Output(
+            val value: Int,
+            val onAction: () -> Unit,
+        )
+
+        override fun initialState(input: Unit): Int = 0
+
+        override fun Snapshot<Unit, Int>.evaluate(): Evaluation<Output> {
+            val next = context.callback {
+                transition(state + 1)
+            }
+            return Evaluation(
+                output = Output(
+                    value = state,
+                    onAction = context.callback {
+                        transition {
+                            next()
+                        }
+                    }
+                )
+            )
+        }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/subjects/ParentUpdateChildAndSelfOnEventRobot.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ParentUpdateChildAndSelfOnEventRobot.kt
@@ -1,0 +1,65 @@
+package com.instacart.formula.subjects
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.rxjava3.RxAction
+import com.instacart.formula.test.TestableRuntime
+import com.instacart.formula.types.IncrementFormula
+import io.reactivex.rxjava3.core.Observable
+
+class ParentUpdateChildAndSelfOnEventRobot(
+    runtime: TestableRuntime,
+) {
+
+    val subject = runtime.test(Parent())
+
+    fun start() = apply {
+        subject.input(Unit)
+    }
+
+    class Parent : Formula<Unit, Parent.State, Parent.Output>() {
+        data class State(
+            val actionId: Int = 0,
+            val value: Int = 0,
+        )
+
+        data class Output(
+            val parentValue: Int,
+            val childValue: Int,
+            val onAction: () -> Unit
+        )
+
+        private val incrementFormula = IncrementFormula()
+
+        override fun initialState(input: Unit): State = State()
+
+        override fun Snapshot<Unit, State>.evaluate(): Evaluation<Output> {
+            val incrementOutput = context.child(incrementFormula)
+            return Evaluation(
+                output = Output(
+                    parentValue = state.value,
+                    childValue = incrementOutput.value,
+                    onAction = context.callback {
+                        val newState = state.copy(actionId = state.actionId + 1)
+                        transition(newState)
+                    }
+                ),
+                actions = context.actions {
+                    if (state.actionId > 0) {
+                        RxAction.fromObservable(state.actionId) {
+                            // Call child
+                            incrementOutput.onIncrement()
+
+                            // Emit events
+                            Observable.just(1, 1, 1)
+                        }.onEvent {
+                            val newState = state.copy(value = state.value + it)
+                            transition(newState)
+                        }
+                    }
+                }
+            )
+        }
+    }
+}


### PR DESCRIPTION
## What

There was a bug in the runtime after the rewrite in which it was possible to get `Transition already happened` exception:
```
Caused by: java.lang.IllegalStateException: Transition already happened. This is using old event listener: 
com.instacart.formula.subjects.IndirectNestedCallbackCallRobot$Parent$evaluate$2$2@3878c24f & 1. 
Transition: 2 != 3
```

This happens in a parent that has more than one child formula.
- Child A formula has already run and is idle 
- Child B formula is running and has a side-effect that causes Child A state to change
- Parent formula evaluation doesn't re-evaluate and causes us to have outdated listeners.

The way to solve this is to have `isEvaluationNeeded` call in `postEvaluation` before processing anything. This will force to re-evaluate again.