### PR TITLE
Remove FragmentFlowState activeKeys and visibleKeys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - **Breaking**: Remove `Integration` and `FragmentContract`
 - **Breaking**: Remove `Stream`, `StreamBuilder` and `StreamFormula`
 - **Breaking**: Rewrite internals of formula action handling to enable inline re-evaluation. Lots of changes, can review them in https://github.com/instacart/formula/pull/301
+- **Breaking**: Remove `FragmentFlowState.activeKeys` and `FragmentFlowState.visibleKeys`
 
 ## [0.7.1] - June 28, 2022
 - **Breaking**: Rename `FragmentBindingBuilder` to `FragmentStoreBuilder`

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentFlowState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentFlowState.kt
@@ -1,10 +1,10 @@
 package com.instacart.formula.android
 
 /**
- * Represents currently [activeKeys] and their [states].
+ * Represents currently [activeIds] and their [states].
  *
- * @param activeKeys Fragment contracts that are running their state management.
- * @param visibleKeys Fragment contracts that are currently visible to the user.
+ * @param activeIds Fragment contracts that are running their state management.
+ * @param visibleIds Fragment contracts that are currently visible to the user.
  * @param states Last emitted state of each active [FragmentKey].
  */
 data class FragmentFlowState(
@@ -13,13 +13,5 @@ data class FragmentFlowState(
     val features: Map<FragmentId, FeatureEvent> = emptyMap(),
     val states: Map<FragmentId, FragmentState> = emptyMap()
 ) {
-    @Deprecated("use activeIds")
-    val activeKeys: List<FragmentKey>
-        get() = activeIds.map { it.key }
-
-    @Deprecated("use visibleIds")
-    val visibleKeys: List<FragmentKey>
-        get() = visibleIds.map { it.key }
-
     fun visibleState() = visibleIds.lastOrNull()?.let { states[it] }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -35,7 +35,7 @@ internal class FragmentFlowRenderView(
     private val onLifecycleEvent: (FragmentLifecycleEvent) -> Unit,
     private val onLifecycleState: (FragmentId, Lifecycle.State) -> Unit,
     private val onFragmentViewStateChanged: (FragmentId, isVisible: Boolean) -> Unit
-) : RenderView<FragmentFlowState> {
+) {
 
     private var fragmentState: FragmentFlowState? = null
     private val visibleFragments: LinkedList<Fragment> = LinkedList()
@@ -119,9 +119,9 @@ internal class FragmentFlowRenderView(
         activity.supportFragmentManager.registerFragmentLifecycleCallbacks(callback, false)
     }
 
-    override val render: Renderer<FragmentFlowState> = Renderer {
-        fragmentState = it
-        updateVisibleFragments(it)
+    fun render(state: FragmentFlowState) {
+        fragmentState = state
+        updateVisibleFragments(state)
     }
 
     fun onBackPressed(): Boolean {


### PR DESCRIPTION
## What

- Clean up of deprecated functions
- Remove renderer and unnecessary equality check