### PR TITLE
RxJavaRuntimeErrorHandler

### DIFF
--- a/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxJavaRuntimeErrorHandler.kt
+++ b/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxJavaRuntimeErrorHandler.kt
@@ -1,0 +1,10 @@
+package com.instacart.formula.rxjava3
+
+interface RxJavaRuntimeErrorHandler {
+    /**
+     * @param error [Throwable] that occurred
+     *
+     * @return true if error was handled, false otherwise
+     */
+    fun onError(error: Throwable): Boolean
+}

--- a/formula/src/main/java/com/instacart/formula/Exceptions.kt
+++ b/formula/src/main/java/com/instacart/formula/Exceptions.kt
@@ -1,0 +1,6 @@
+package com.instacart.formula
+
+/**
+ * Thrown when a child formula is added with a duplicate key.
+ */
+class DuplicateKeyException(override val message: String?) : IllegalStateException()

--- a/formula/src/main/java/com/instacart/formula/internal/SingleRequestHolder.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SingleRequestHolder.kt
@@ -1,5 +1,7 @@
 package com.instacart.formula.internal
 
+import com.instacart.formula.DuplicateKeyException
+
 /**
  * Holder tracks when object has already been request and throws an error if requested again. This
  * is used to track duplicate requests for a particular key.
@@ -9,7 +11,7 @@ internal class SingleRequestHolder<T>(val value: T) {
 
     inline fun requestAccess(errorMessage: () -> String): T {
         if (requested) {
-            throw IllegalStateException(errorMessage())
+            throw DuplicateKeyException(errorMessage())
         }
 
         requested = true

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -7,6 +7,7 @@ import com.instacart.formula.internal.ClearPluginsRule
 import com.instacart.formula.internal.TestInspector
 import com.instacart.formula.internal.Try
 import com.instacart.formula.rxjava3.RxAction
+import com.instacart.formula.rxjava3.RxJavaRuntime
 import com.instacart.formula.subjects.ChildActionFiresParentEventOnStart
 import com.instacart.formula.subjects.ChildMessageNoParentStateChange
 import com.instacart.formula.subjects.ChildMessageTriggersEventTransitionInParent
@@ -1108,7 +1109,9 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
         }
 
         val error = result.errorOrNull()?.cause
-        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error).isInstanceOf(DuplicateKeyException::class.java)
+        val expectedMessage = "There already is a child with same key: FormulaKey(scopeKey=null, type=class com.instacart.formula.subjects.KeyFormula, key=TestKey(id=1)). Override [Formula.key] function."
+        assertThat(error?.message).isEqualTo(expectedMessage)
     }
 
     @Test

--- a/formula/src/test/java/com/instacart/formula/error/RxJavaRuntimeErrorHandlerTest.kt
+++ b/formula/src/test/java/com/instacart/formula/error/RxJavaRuntimeErrorHandlerTest.kt
@@ -1,0 +1,95 @@
+package com.instacart.formula.error
+
+import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.Action
+import com.instacart.formula.DuplicateKeyException
+import com.instacart.formula.internal.ClearPluginsRule
+import com.instacart.formula.internal.Try
+import com.instacart.formula.rxjava3.RxJavaRuntime
+import com.instacart.formula.rxjava3.RxJavaRuntimeErrorHandler
+import com.instacart.formula.subjects.DynamicParentFormula
+import com.instacart.formula.subjects.OnlyUpdateFormula
+import com.instacart.formula.subjects.TestKey
+import com.instacart.formula.test.RxJavaTestableRuntime
+import com.instacart.formula.test.TestableRuntime
+import org.junit.After
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.rules.RuleChain
+import org.junit.rules.TestName
+import kotlin.IllegalStateException
+
+class RxJavaRuntimeErrorHandlerTest {
+
+    val runtime: TestableRuntime = RxJavaTestableRuntime
+
+    @get:Rule
+    val rule = RuleChain
+        .outerRule(TestName())
+        .around(ClearPluginsRule())
+        .around(runtime.rule)
+
+    private val errorLogs = mutableListOf<String>()
+
+    private val duplicateKeyErrorHandler = object : RxJavaRuntimeErrorHandler {
+        override fun onError(error: Throwable): Boolean {
+            return when (error) {
+                is DuplicateKeyException -> {
+                    errorLogs.add(error.message.orEmpty())
+                    true
+                }
+
+                else -> {
+                    false
+                }
+            }
+        }
+    }
+
+    @Before
+    fun setUp() {
+        RxJavaRuntime.setDefaultErrorHandler(duplicateKeyErrorHandler)
+    }
+
+    @After
+    fun tearDown() {
+        RxJavaRuntime.setDefaultErrorHandler(null)
+    }
+
+    @Test
+    fun `emitting a generic error throws an exception`() {
+        val result = Try {
+            val formula = OnlyUpdateFormula<Unit> {
+                events(Action.onInit()) {
+                    throw IllegalStateException("crashed")
+                }
+            }
+            runtime.test(formula, Unit)
+        }
+
+        val error = result.errorOrNull()?.cause
+        assertThat(error).isInstanceOf(IllegalStateException::class.java)
+        assertThat(error?.message).isEqualTo("crashed")
+
+        assertThat(errorLogs).isEmpty()
+    }
+
+    @Test
+    fun `adding duplicate child logs an exception`() {
+        val result = Try {
+            val formula = DynamicParentFormula()
+            runtime.test(formula, Unit)
+                .output { addChild(TestKey("1")) }
+                .output { addChild(TestKey("1")) }
+        }
+
+        val error = result.errorOrNull()?.cause
+        assertThat(error).isNull()
+        assertThat(errorLogs).hasSize(1)
+
+        val log = errorLogs.first()
+        val expectedLog = "There already is a child with same key: FormulaKey(scopeKey=null, type=class com.instacart.formula.subjects.KeyFormula, key=TestKey(id=1)). Override [Formula.key] function."
+        assertThat(log).isEqualTo(expectedLog)
+    }
+}


### PR DESCRIPTION
Add ability to handle errors in `RxJavaRuntime`. This allows clients to catch errors and handle accordingly, i.e. throw in debug builds but log in production builds. The primary use case is centered around handling `duplicate child key` exceptions, which have caused issues for us in the past