### PR TITLE
Handle duplicate child key errors more gracefully.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
@@ -18,4 +18,12 @@ object FormulaPlugins {
             else -> ListInspector(listOf(global, local))
         }
     }
+
+    fun onDuplicateChildKey(
+        parentFormulaType: Class<*>,
+        childFormulaType: Class<*>,
+        key: Any,
+    ) {
+       plugin?.onDuplicateChildKey(parentFormulaType, childFormulaType, key)
+    }
 }

--- a/formula/src/main/java/com/instacart/formula/Plugin.kt
+++ b/formula/src/main/java/com/instacart/formula/Plugin.kt
@@ -12,4 +12,13 @@ interface Plugin {
     fun inspector(type: KClass<*>): Inspector? {
         return null
     }
+
+    /**
+     * Notified when there is a duplicate child key detected.
+     */
+    fun onDuplicateChildKey(
+        parentType: Class<*>,
+        childFormulaType: Class<*>,
+        key: Any,
+    ) = Unit
 }

--- a/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
@@ -1,7 +1,9 @@
 package com.instacart.formula.internal
 
+import com.instacart.formula.FormulaPlugins
 import com.instacart.formula.IFormula
 import com.instacart.formula.Inspector
+import java.lang.IllegalStateException
 
 /**
  * Keeps track of child formula managers.
@@ -11,7 +13,10 @@ internal class ChildrenManager(
     private val inspector: Inspector?,
 ) {
     private var children: SingleRequestMap<Any, FormulaManager<*, *>>? = null
+    private var indexes: MutableMap<Any, Int>? = null
     private var pendingRemoval: MutableList<FormulaManager<*, *>>? = null
+
+    private var duplicateKeyLogs: MutableSet<Any>? = null
 
     /**
      * After evaluation, we iterate over detached child formulas, mark them as terminated
@@ -19,6 +24,8 @@ internal class ChildrenManager(
      * in post evaluation, which will call [terminateChildren] function.
      */
     fun prepareForPostEvaluation() {
+        indexes?.clear()
+
         children?.clearUnrequested {
             pendingRemoval = pendingRemoval ?: mutableListOf()
             it.markAsTerminated()
@@ -51,6 +58,48 @@ internal class ChildrenManager(
         formula: IFormula<ChildInput, ChildOutput>,
         input: ChildInput,
     ): FormulaManager<ChildInput, ChildOutput> {
+        val childHolder = childFormulaHolder(key, formula, input)
+        return if (childHolder.requested) {
+            val logs = duplicateKeyLogs ?: run {
+                val newSet = mutableSetOf<Any>()
+                duplicateKeyLogs = newSet
+                newSet
+            }
+
+            /**
+             * Since child key was already requested, we use a fallback mechanism that
+             * uses index increment to handle collisions. This is better than crashing, but
+             * can lead to subtle bugs when content shifts. We notify the global listener
+             * so it can be logged and fixed by defining explicit key.
+             */
+            if (logs.add(key)) {
+                FormulaPlugins.onDuplicateChildKey(
+                    parentFormulaType = delegate.loggingType.java,
+                    childFormulaType = formula.type().java,
+                    key = key,
+                )
+            }
+
+            if (key is IndexedKey) {
+                // This should never happen, but added as safety
+                throw IllegalStateException("Key already indexed (and still duplicate).")
+            }
+
+            val index = nextIndex(key)
+            val indexedKey = IndexedKey(key, index)
+            findOrInitChild(indexedKey, formula, input)
+        } else {
+            childHolder.requestAccess {
+                "There already is a child with same key: $key. Override [Formula.key] function."
+            }
+        }
+    }
+
+    private fun <ChildInput, ChildOutput>  childFormulaHolder(
+        key: Any,
+        formula: IFormula<ChildInput, ChildOutput>,
+        input: ChildInput,
+    ): SingleRequestHolder<FormulaManager<ChildInput, ChildOutput>> {
         @Suppress("UNCHECKED_CAST")
         val children = children ?: run {
             val initialized: SingleRequestMap<Any, FormulaManager<*, *>> = LinkedHashMap()
@@ -58,13 +107,33 @@ internal class ChildrenManager(
             initialized
         }
 
-        return children
-            .findOrInit(key) {
-                val implementation = formula.implementation()
-                FormulaManagerImpl(delegate, implementation, input, loggingType = formula::class, inspector = inspector)
-            }
-            .requestAccess {
-                "There already is a child with same key: $key. Override [Formula.key] function."
-            } as FormulaManager<ChildInput, ChildOutput>
+        val childFormulaHolder = children.findOrInit(key) {
+            val implementation = formula.implementation()
+            FormulaManagerImpl(
+                delegate,
+                implementation,
+                input,
+                loggingType = formula::class,
+                inspector = inspector
+            )
+        }
+        @Suppress("UNCHECKED_CAST")
+        return childFormulaHolder as SingleRequestHolder<FormulaManager<ChildInput, ChildOutput>>
+    }
+
+    /**
+     * Function which returns next index for a given key. It will
+     * mutate the [indexes] map.
+     */
+    private fun nextIndex(key: Any): Int {
+        val indexes = indexes ?: run {
+            val initialized = mutableMapOf<Any, Int>()
+            this.indexes = initialized
+            initialized
+        }
+
+        val index = indexes.getOrElse(key) { 0 } + 1
+        indexes[key] = index
+        return index
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -21,7 +21,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
     private val delegate: ManagerDelegate,
     private val formula: Formula<Input, State, Output>,
     initialInput: Input,
-    private val loggingType: KClass<*>,
+    internal val loggingType: KClass<*>,
     private val listeners: Listeners = Listeners(),
     private val inspector: Inspector?,
 ) : FormulaManager<Input, Output>, ManagerDelegate {


### PR DESCRIPTION
## What
Instead of crashing on duplicate child key, we now add an index and notify the global listener to fix the problem. This is better behavior in production than potentially breaking the whole screen.
