### PR TITLE
Replace event listener with FragmentDelegate class.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
@@ -132,20 +132,16 @@ class FormulaFragment : Fragment(), BaseFormulaFragment<Any> {
 
         val fragmentId = getFormulaFragmentId()
         val environment = FormulaFragmentDelegate.fragmentEnvironment()
+        val fragmentDelegate = environment.fragmentDelegate
 
         try {
-            val start = SystemClock.uptimeMillis()
-            view.setOutput(output)
-            val end = SystemClock.uptimeMillis()
-
-            environment.eventListener?.onRendered(
-                fragmentId = fragmentId,
-                durationInMillis = end - start,
-            )
+            fragmentDelegate.setOutput(fragmentId, output, view.setOutput)
 
             if (firstRender) {
+                val end = SystemClock.uptimeMillis()
+
                 firstRender = false
-                environment.eventListener?.onFirstModelRendered(
+                fragmentDelegate.onFirstModelRendered(
                     fragmentId = fragmentId,
                     durationInMillis = end - (initializedAtMillis ?: SystemClock.uptimeMillis()),
                 )

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -34,13 +34,12 @@ internal class FeatureBinding<in Component, in Dependencies, in Key : FragmentKe
                             Action.onData(fragmentId).onEvent {
                                 transition {
                                     try {
-                                        val start = SystemClock.uptimeMillis()
                                         val dependencies = toDependencies(input.component)
-                                        val feature = feature.initialize(dependencies, key as Key)
-                                        val end = SystemClock.uptimeMillis()
-                                        input.environment.eventListener?.onFeatureInitialized(
+                                        val feature = input.environment.fragmentDelegate.initializeFeature(
                                             fragmentId = fragmentId,
-                                            durationInMillis = end - start,
+                                            factory = feature,
+                                            dependencies = dependencies,
+                                            key = key as Key,
                                         )
                                         input.onInitializeFeature(FeatureEvent.Init(fragmentId, feature))
                                     } catch (e: Exception) {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentViewFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentViewFactory.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.android.internal
 
-import android.os.SystemClock
 import android.view.LayoutInflater
 import android.view.ViewGroup
 import com.instacart.formula.android.FeatureView
@@ -20,7 +19,6 @@ internal class FormulaFragmentViewFactory(
 
     @Suppress("UNCHECKED_CAST")
     override fun create(inflater: LayoutInflater, container: ViewGroup?): FeatureView<Any> {
-        val start = SystemClock.uptimeMillis()
         val key = fragmentId.key
         val featureEvent = featureProvider.getFeature(fragmentId) ?: throw IllegalStateException("Could not find feature for $key.")
         val viewFactory = factory ?: when (featureEvent) {
@@ -35,9 +33,7 @@ internal class FormulaFragmentViewFactory(
             }
         }
         this.factory = viewFactory
-        val view = viewFactory.create(inflater, container)
-        val endTime = SystemClock.uptimeMillis()
-        environment.eventListener?.onViewInflated(fragmentId, endTime - start)
-        return view
+        val delegate = environment.fragmentDelegate
+        return delegate.createView(fragmentId, viewFactory, inflater, container)
     }
 }


### PR DESCRIPTION
## What

Instead of tracking performance internally within the `formula-android` module, I'm replacing it with a delegating API that allows for more flexible patterns.