### PR TITLE
[Fragment] Add onNewInstance callback.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentEnvironment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentEnvironment.kt
@@ -15,6 +15,13 @@ data class FragmentEnvironment(
     open class FragmentDelegate {
 
         /**
+         * Called when new instance of [FormulaFragment] is created.
+         */
+        open fun onNewInstance(
+            fragmentId: FragmentId
+        ) = Unit
+
+        /**
          * Instantiates the feature.
          */
         open fun <DependenciesT, KeyT: FragmentKey> initializeFeature(
@@ -44,11 +51,5 @@ data class FragmentEnvironment(
         open fun setOutput(fragmentId: FragmentId, output: Any, applyOutputToView: (Any) -> Unit) {
             applyOutputToView(output)
         }
-
-        /**
-         * Called after first render model is rendered. The [durationInMillis] starts
-         * when formula fragment is initialized and ends after first render model is applied.
-         */
-        open fun onFirstModelRendered(fragmentId: FragmentId, durationInMillis: Long) = Unit
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -95,8 +95,6 @@ internal class FragmentFlowRenderView(
 
         override fun onFragmentAttached(fm: FragmentManager, f: Fragment, context: Context) {
             super.onFragmentAttached(fm, f, context)
-            initializeFragmentInstanceIdIfNeeded(f)
-
             if (FragmentLifecycle.shouldTrack(f)) {
                 onLifecycleEvent(FragmentLifecycle.createAddedEvent(f))
             } else {
@@ -141,7 +139,6 @@ internal class FragmentFlowRenderView(
     }
 
     fun viewFactory(fragment: FormulaFragment): ViewFactory<Any> {
-        initializeFragmentInstanceIdIfNeeded(fragment)
         return FormulaFragmentViewFactory(
             environment = fragmentEnvironment,
             fragmentId = fragment.getFormulaFragmentId(),
@@ -159,25 +156,6 @@ internal class FragmentFlowRenderView(
                 state.states[fragment.getFormulaFragmentId()]?.let {
                     (fragment as BaseFormulaFragment<Any>).setState(it.renderModel)
                 }
-            }
-        }
-    }
-
-    /**
-     * Creates a unique identifier the first time fragment is attached that
-     * is persisted across configuration changes.
-     */
-    private fun initializeFragmentInstanceIdIfNeeded(f: Fragment) {
-        if (f is BaseFormulaFragment<*>) {
-            val arguments = f.arguments ?: run {
-                Bundle().apply {
-                    f.arguments = this
-                }
-            }
-            val id = arguments.getString(FormulaFragment.ARG_FORMULA_ID, "")
-            if (id.isNullOrBlank()) {
-                val initializedId = UUID.randomUUID().toString()
-                arguments.putString(FormulaFragment.ARG_FORMULA_ID, initializedId)
             }
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentLifecycle.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentLifecycle.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula.android.internal
 
+import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentInspector
 import androidx.fragment.app.FragmentManager
@@ -8,6 +9,7 @@ import com.instacart.formula.android.FragmentKey
 import com.instacart.formula.android.BaseFormulaFragment
 import com.instacart.formula.android.FormulaFragment
 import com.instacart.formula.android.events.FragmentLifecycleEvent
+import java.util.UUID
 
 /**
  * Provides utility method [lifecycleEvents] to track what fragments are added and removed from the backstack.
@@ -37,8 +39,28 @@ private fun Fragment.getFragmentKey(): FragmentKey {
     return fragment?.getFragmentKey() ?: EmptyFragmentKey(tag.orEmpty())
 }
 
+/**
+ * Gets a persisted across configuration changes fragment identifier or initializes
+ * one if it doesn't exist.
+ */
 private fun Fragment.getFragmentInstanceId(): String {
-    return arguments?.getString(FormulaFragment.ARG_FORMULA_ID) ?: ""
+    return if (this is BaseFormulaFragment<*>) {
+        val arguments = arguments ?: run {
+            Bundle().apply {
+                arguments = this
+            }
+        }
+        val id = arguments.getString(FormulaFragment.ARG_FORMULA_ID, "")
+        if (id.isNullOrBlank()) {
+            val initializedId = UUID.randomUUID().toString()
+            arguments.putString(FormulaFragment.ARG_FORMULA_ID, initializedId)
+            initializedId
+        } else {
+            id
+        }
+    } else {
+        ""
+    }
 }
 
 internal fun Fragment.getFormulaFragmentId(): FragmentId {


### PR DESCRIPTION
## What
Removing `onFirstModel` callback in favor of exposing `onNewInstance` and moving the first model logic out of the core library.