### PR TITLE
Fix lint build.

### DIFF
--- a/formula-lint/build.gradle.kts
+++ b/formula-lint/build.gradle.kts
@@ -1,3 +1,6 @@
+import com.android.build.gradle.internal.lint.AndroidLintAnalysisTask
+import com.android.build.gradle.internal.lint.LintModelWriterTask
+
 plugins {
   id("java-library")
   id("kotlin")
@@ -18,4 +21,13 @@ dependencies {
   testImplementation(libs.lint.core)
   testImplementation(libs.lint.tests)
   testImplementation(libs.junit)
+}
+
+// Need to register direct task dependencies since jacocoTestReport is
+// accessing the files produced by those lint tasks
+plugins.withId("jacoco") {
+  tasks.named("jacocoTestReport") {
+    dependsOn(tasks.withType(AndroidLintAnalysisTask::class.java))
+    dependsOn(tasks.withType(LintModelWriterTask::class.java))
+  }
 }

--- a/formula-lint/build.gradle.kts
+++ b/formula-lint/build.gradle.kts
@@ -27,7 +27,7 @@ dependencies {
 // accessing the files produced by those lint tasks
 plugins.withId("jacoco") {
   tasks.named("jacocoTestReport") {
-    dependsOn(tasks.withType(AndroidLintAnalysisTask::class.java))
-    dependsOn(tasks.withType(LintModelWriterTask::class.java))
+    dependsOn(tasks.withType<AndroidLintAnalysisTask>())
+    dependsOn(tasks.withType<LintModelWriterTask>())
   }
 }


### PR DESCRIPTION
## What
Fixing the following issue when running `:formula-lint:build`

```
* What went wrong:
A problem was found with the configuration of task ':formula-lint:lintAnalyzeJvm' (type 'AndroidLintAnalysisTask').
  - Gradle detected a problem with the following location: '/Users/laimonasturauskas/android/formula/formula-lint/build/intermediates/lint_partial_results/global/lintAnalyzeJvm'.
    
    Reason: Task ':formula-lint:jacocoTestReport' uses this output of task ':formula-lint:lintAnalyzeJvm' without declaring an explicit or implicit dependency. This can lead to incorrect results being produced, depending on what order the tasks are executed.
    
    Possible solutions:
      1. Declare task ':formula-lint:lintAnalyzeJvm' as an input of ':formula-lint:jacocoTestReport'.
      2. Declare an explicit dependency on ':formula-lint:lintAnalyzeJvm' from ':formula-lint:jacocoTestReport' using Task#dependsOn.
      3. Declare an explicit dependency on ':formula-lint:lintAnalyzeJvm' from ':formula-lint:jacocoTestReport' using Task#mustRunAfter.
    
    For more information, please refer to https://docs.gradle.org/8.2/userguide/validation_problems.html#implicit_dependency in the Gradle documentation.

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

```