### PR TITLE
[Android] Ensure all events touching Android happen on the main thread.

### DIFF
--- a/formula-android-tests/build.gradle.kts
+++ b/formula-android-tests/build.gradle.kts
@@ -40,11 +40,11 @@ dependencies {
     implementation(libs.lifecycle.extensions)
     implementation(libs.androidx.test.core.ktx)
 
-    testImplementation(libs.junit)
-    testImplementation(libs.truth)
     testImplementation(libs.androidx.test.junit)
     testImplementation(libs.androidx.test.rules)
     testImplementation(libs.androidx.test.runner)
     testImplementation(libs.espresso.core)
+    testImplementation(libs.junit)
     testImplementation(libs.robolectric)
+    testImplementation(libs.truth)
 }

--- a/formula-android-tests/src/test/java/com/instacart/formula/android/internal/AndroidUpdateSchedulerTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/android/internal/AndroidUpdateSchedulerTest.kt
@@ -1,0 +1,77 @@
+package com.instacart.formula.android.internal
+
+import android.os.Looper
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.Shadows.shadowOf
+import java.util.LinkedList
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+
+@RunWith(AndroidJUnit4::class)
+class AndroidUpdateSchedulerTest {
+
+    @Test fun `when an update triggers another update, scheduler finishes first one before proceeding to the next`() {
+        val computedValues = LinkedList<String>()
+        val scheduler = AndroidUpdateScheduler<() -> String> { valueComputation ->
+            val value = valueComputation()
+            computedValues.addLast(value)
+        }
+
+        scheduler.emitUpdate {
+            scheduler.emitUpdate { "next" }
+            "first"
+        }
+
+        assertThat(computedValues).containsExactly("first", "next").inOrder()
+    }
+
+    @Test fun `when update arrives on bg thread, handle it on main thread`() {
+        val computedValues = LinkedList<String>()
+        val scheduler = AndroidUpdateScheduler<() -> String> { valueComputation ->
+            val value = valueComputation()
+            computedValues.addLast(value)
+        }
+
+        val latch = CountDownLatch(1)
+        Executors.newSingleThreadExecutor().execute {
+            scheduler.emitUpdate { "bg update" }
+            latch.countDown()
+        }
+
+        if (!latch.await(100, TimeUnit.MILLISECONDS)) {
+            throw IllegalStateException("timeout")
+        }
+
+        shadowOf(Looper.getMainLooper()).idle()
+        assertThat(computedValues).containsExactly("bg update").inOrder()
+    }
+
+    @Test fun `when multiple updates arrive on bg thread before main thread is ready, we handle only last`() {
+        val computedValues = LinkedList<String>()
+        val scheduler = AndroidUpdateScheduler<() -> String> { valueComputation ->
+            val value = valueComputation()
+            computedValues.addLast(value)
+        }
+
+        val latch = CountDownLatch(1)
+        Executors.newSingleThreadExecutor().execute {
+            scheduler.emitUpdate { "bg update-1" }
+            scheduler.emitUpdate { "bg update-2" }
+            scheduler.emitUpdate { "bg update-3" }
+            scheduler.emitUpdate { "bg update-4" }
+            latch.countDown()
+        }
+
+        if (!latch.await(100, TimeUnit.MILLISECONDS)) {
+            throw IllegalStateException("timeout")
+        }
+
+        shadowOf(Looper.getMainLooper()).idle()
+        assertThat(computedValues).containsExactly("bg update-4").inOrder()
+    }
+}

--- a/formula-android/build.gradle.kts
+++ b/formula-android/build.gradle.kts
@@ -31,12 +31,15 @@ dependencies {
     api(libs.rxandroid)
     api(libs.rxrelay)
 
+
     testImplementation(libs.androidx.test.rules)
     testImplementation(libs.androidx.test.runner)
+    testImplementation(libs.androidx.test.junit)
     testImplementation(libs.espresso.core)
-    testImplementation(libs.truth)
+    testImplementation(libs.kotlin.reflect)
     testImplementation(libs.mockito.core)
     testImplementation(libs.mockito.kotlin)
-    testImplementation(libs.kotlin.reflect)
+    testImplementation(libs.robolectric)
+    testImplementation(libs.truth)
 }
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -71,9 +71,11 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
     }
 
     override fun send(effect: Activity.() -> Unit) {
-        // We allow emitting effects only after activity has started
-        startedActivity()?.effect() ?: run {
-            // Log missing activity.
+        Utils.executeOnMainThread {
+            // We allow emitting effects only after activity has started
+            startedActivity()?.effect() ?: run {
+                // Log missing activity.
+            }
         }
     }
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -71,10 +71,12 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
     }
 
     override fun send(effect: Activity.() -> Unit) {
-        Utils.executeOnMainThread {
-            // We allow emitting effects only after activity has started
-            startedActivity()?.effect() ?: run {
-                // Log missing activity.
+        // We allow emitting effects only after activity has started
+        if (Utils.isMainThread()) {
+           startedActivity()?.effect()
+        } else {
+            Utils.mainThreadHandler.post {
+                startedActivity()?.effect()
             }
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
@@ -26,7 +26,7 @@ class AndroidUpdateScheduler<Value : Any>(
      */
     private var isUpdating = false
 
-    private val updateRunnable = object :Runnable {
+    private val updateRunnable = object : Runnable {
         override fun run() {
             updateScheduled.set(false)
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
@@ -38,7 +38,7 @@ class AndroidUpdateScheduler<Value : Any>(
                 isUpdating = false
 
                 // Check if another update arrived while we were processing.
-                localPending =  pendingValue.getAndSet(null)
+                localPending = pendingValue.getAndSet(null)
 
                 if (localPending != null) {
                     // We will take over processing, so let's clear the message
@@ -63,7 +63,6 @@ class AndroidUpdateScheduler<Value : Any>(
         } else {
             // If no update is scheduled, schedule one
             if (updateScheduled.compareAndSet(false, true)) {
-
                 Utils.mainThreadHandler.post(updateRunnable)
             }
         }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
@@ -1,0 +1,71 @@
+package com.instacart.formula.android.internal
+
+import java.util.concurrent.atomic.AtomicBoolean
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * Handles state update scheduling to the main thread. If update arrives on a background thread,
+ * it will added it the main thread queue. It will throw away a pending update if a new update
+ * arrives.
+ */
+class AndroidUpdateScheduler<Value : Any>(
+    private val update: (Value) -> Unit,
+) {
+    /**
+     * If not null, that means that we have an update pending.
+     */
+    private val pendingValue = AtomicReference<Value>()
+
+    /**
+     * Defines if an update is currently scheduled.
+     */
+    private val updateScheduled = AtomicBoolean(false)
+
+    /**
+     * To avoid re-entry, we track if [updateRunnable] is currently handling an update.
+     */
+    private var isUpdating = false
+
+    private val updateRunnable = object :Runnable {
+        override fun run() {
+            updateScheduled.set(false)
+
+            var localPending = pendingValue.getAndSet(null)
+            while (localPending != null) {
+                // Handle the update
+                isUpdating = true
+                update(localPending)
+                isUpdating = false
+
+                // Check if another update arrived while we were processing.
+                localPending =  pendingValue.getAndSet(null)
+
+                if (localPending != null) {
+                    // We will take over processing, so let's clear the message
+                    Utils.mainThreadHandler.removeCallbacks(this)
+                }
+            }
+        }
+    }
+
+    fun emitUpdate(value: Value) {
+        // Set pending value
+        pendingValue.set(value)
+
+        if (Utils.isMainThread()) {
+            if (isUpdating) {
+                // Let's exit and let the [updateRunnable] to pick up the change
+                return
+            } else {
+                // Since we are on main thread, let's force run it
+                updateRunnable.run()
+            }
+        } else {
+            // If no update is scheduled, schedule one
+            if (updateScheduled.compareAndSet(false, true)) {
+
+                Utils.mainThreadHandler.post(updateRunnable)
+            }
+        }
+    }
+}

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
@@ -28,10 +28,10 @@ class AndroidUpdateScheduler<Value : Any>(
 
     private val updateRunnable = object : Runnable {
         override fun run() {
-            updateScheduled.set(false)
-
             var localPending = pendingValue.getAndSet(null)
             while (localPending != null) {
+                updateScheduled.set(false)
+
                 // Handle the update
                 isUpdating = true
                 update(localPending)

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/AndroidUpdateScheduler.kt
@@ -28,10 +28,10 @@ class AndroidUpdateScheduler<Value : Any>(
 
     private val updateRunnable = object : Runnable {
         override fun run() {
+            updateScheduled.set(false)
+
             var localPending = pendingValue.getAndSet(null)
             while (localPending != null) {
-                updateScheduled.set(false)
-
                 // Handle the update
                 isUpdating = true
                 update(localPending)
@@ -41,7 +41,8 @@ class AndroidUpdateScheduler<Value : Any>(
                 localPending = pendingValue.getAndSet(null)
 
                 if (localPending != null) {
-                    // We will take over processing, so let's clear the message
+                    // We will perform the update, let's clear the values.
+                    updateScheduled.set(false)
                     Utils.mainThreadHandler.removeCallbacks(this)
                 }
             }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
@@ -72,10 +72,7 @@ internal class CompositeBinding<ParentComponent, ScopedComponent>(
     override fun types(): Set<Class<*>> = types
 
     override fun binds(key: Any): Boolean {
-        bindings.forEachIndices {
-            if (it.binds(key)) return true
-        }
-        return false
+        return types.contains(key.javaClass)
     }
 
     override fun bind(context: FormulaContext<*, *>, input: Input<ParentComponent>) {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/CompositeBinding.kt
@@ -72,7 +72,10 @@ internal class CompositeBinding<ParentComponent, ScopedComponent>(
     override fun types(): Set<Class<*>> = types
 
     override fun binds(key: Any): Boolean {
-        return types.contains(key.javaClass)
+        bindings.forEachIndices {
+            if (it.binds(key)) return true
+        }
+        return false
     }
 
     override fun bind(context: FormulaContext<*, *>, input: Input<ParentComponent>) {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -32,7 +32,6 @@ internal class FeatureBinding<in Component, in Dependencies, in Key : FragmentKe
                         if (binds(key)) {
                             Action.onData(fragmentId).onEvent {
                                 transition {
-                                    // TODO: should this happen on the main thread? It needs to be available to main thread
                                     try {
                                         val dependencies = toDependencies(input.component)
                                         val feature = input.environment.fragmentDelegate.initializeFeature(

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.android.internal
 
-import android.os.SystemClock
 import com.instacart.formula.Action
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -33,6 +33,7 @@ internal class FeatureBinding<in Component, in Dependencies, in Key : FragmentKe
                         if (binds(key)) {
                             Action.onData(fragmentId).onEvent {
                                 transition {
+                                    // TODO: should this happen on the main thread? It needs to be available to main thread
                                     try {
                                         val dependencies = toDependencies(input.component)
                                         val feature = input.environment.fragmentDelegate.initializeFeature(

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
@@ -1,0 +1,29 @@
+package com.instacart.formula.android.internal
+
+import com.instacart.formula.Action
+import com.instacart.formula.Cancelable
+import com.instacart.formula.android.Feature
+import com.instacart.formula.android.FragmentEnvironment
+import com.instacart.formula.android.FragmentId
+import io.reactivex.rxjava3.core.Observable
+
+class FeatureObservableAction(
+    private val fragmentEnvironment: FragmentEnvironment,
+    private val fragmentId: FragmentId,
+    private val feature: Feature<*>,
+) : Action<Any> {
+
+    override fun key(): Any = fragmentId
+
+    override fun start(send: (Any) -> Unit): Cancelable {
+        val observable = feature.state.onErrorResumeNext {
+            fragmentEnvironment.onScreenError(fragmentId.key, it)
+            Observable.empty()
+        }
+
+        // We ensure all feature state updates come on the main thread.
+        val androidUpdateScheduler = AndroidUpdateScheduler(send)
+        val disposable = observable.subscribe(androidUpdateScheduler::emitUpdate)
+        return Cancelable(disposable::dispose)
+    }
+}

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -42,7 +42,6 @@ internal class FragmentFlowRenderView(
 
     private val featureProvider = object : FeatureProvider {
         override fun getFeature(id: FragmentId): FeatureEvent? {
-            // TODO: should we initialize feature if it's missing
             return fragmentState?.features?.get(id)
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -42,6 +42,7 @@ internal class FragmentFlowRenderView(
 
     private val featureProvider = object : FeatureProvider {
         override fun getFeature(id: FragmentId): FeatureEvent? {
+            // TODO: should we initialize feature if it's missing
             return fragmentState?.features?.get(id)
         }
     }
@@ -118,6 +119,8 @@ internal class FragmentFlowRenderView(
     }
 
     fun render(state: FragmentFlowState) {
+        Utils.assertMainThread()
+
         fragmentState = state
         updateVisibleFragments(state)
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/StreamConfiguratorIml.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/StreamConfiguratorIml.kt
@@ -18,14 +18,17 @@ internal class StreamConfiguratorIml<out Activity : FragmentActivity>(
         val stateEmissions = Observable.combineLatest(
             state,
             context.activityStartedEvents(),
-            BiFunction<State, Unit, State> { state, event ->
-                state
+            BiFunction { stateValue, _ ->
+                stateValue
             }
         )
-        return stateEmissions.subscribe { state ->
+
+        val updateScheduler = AndroidUpdateScheduler<State> { stateValue ->
             context.startedActivity()?.let {
-                update(it, state)
+                update(it, stateValue)
             }
         }
+
+        return stateEmissions.subscribe(updateScheduler::emitUpdate)
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
@@ -1,11 +1,26 @@
 package com.instacart.formula.android.internal
 
+import android.os.Handler
 import android.os.Looper
 
 internal object Utils {
+    internal val mainThreadHandler = Handler(Looper.getMainLooper())
+
     fun assertMainThread() {
-        if (Looper.getMainLooper() != Looper.myLooper()) {
+        if (!isMainThread()) {
             throw IllegalStateException("should be called on main thread: ${Thread.currentThread()}")
         }
+    }
+
+    inline fun executeOnMainThread(crossinline runnable: () -> Unit) {
+        if (isMainThread()) {
+            runnable()
+        } else {
+            mainThreadHandler.post { runnable() }
+        }
+    }
+
+    fun isMainThread(): Boolean {
+        return Looper.getMainLooper() == Looper.myLooper()
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/Utils.kt
@@ -12,14 +12,6 @@ internal object Utils {
         }
     }
 
-    inline fun executeOnMainThread(crossinline runnable: () -> Unit) {
-        if (isMainThread()) {
-            runnable()
-        } else {
-            mainThreadHandler.post { runnable() }
-        }
-    }
-
     fun isMainThread(): Boolean {
         return Looper.getMainLooper() == Looper.myLooper()
     }


### PR DESCRIPTION
## What

Given we are starting to support non-main threads within formula core (#332), we need to make sure that our Android module handles this change more robustly. To ensure this, I've been auditing various entries and making them thread-safe. 

- `fun send(effect: Activity.() -> Unit)` will now ensure that an activity side-effect is executed on the main thread
- Fragment state changes now uses`AndroidUpdateScheduler` to ensure that they happen on the main thread
- Activity update function now also uses `AndroidUpdateScheduler` to ensure updates happen on the main thread

The new `AndroidUpdateScheduler` class helps coordinate state updates to the main thread. If there are multiple updates before the main thread can handle them, it will only process the last update throwing all the previous values away. This mechanism should help reduce unnecessary intermediate updates.
