### PR TITLE
Separate formula emit from evaluate.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -44,6 +44,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
      * start new actions. And then, [performTerminationSideEffects] is called to clean
      * up this [formula] and its child formulas.
      */
+    @Volatile
     private var terminated = false
 
     /**

--- a/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
@@ -9,10 +9,9 @@ import com.instacart.formula.Transition
 @PublishedApi
 internal class ListenerImpl<Input, State, EventT>(internal var key: Any) : Listener<EventT> {
 
-    internal var manager: FormulaManagerImpl<Input, State, *>? = null
-    internal var snapshotImpl: SnapshotImpl<Input, State>? = null
-
-    internal lateinit var transition: Transition<Input, State, EventT>
+    @Volatile internal var manager: FormulaManagerImpl<Input, State, *>? = null
+    @Volatile internal var snapshotImpl: SnapshotImpl<Input, State>? = null
+    @Volatile internal lateinit var transition: Transition<Input, State, EventT>
 
     override fun invoke(event: EventT) {
         // TODO: log if null listener (it might be due to formula removal or due to callback removal)

--- a/formula/src/main/java/com/instacart/formula/internal/SynchronizedUpdateQueue.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SynchronizedUpdateQueue.kt
@@ -13,7 +13,9 @@ import java.util.concurrent.atomic.AtomicReference
  * that there is happens-before relationship between each thread and memory changes are visible
  * between them.
  */
-class SynchronizedUpdateQueue {
+class SynchronizedUpdateQueue(
+    private val onEmpty: (() -> Unit)? = null,
+) {
     /**
      * Defines a thread currently executing formula update. Null value indicates idle queue.
      *
@@ -79,6 +81,7 @@ class SynchronizedUpdateQueue {
                     return
                 }
             } else {
+                onEmpty?.invoke()
                 return
             }
         }


### PR DESCRIPTION
## What

Currently, formula evaluations will have to wait until output emission is finalized. If formula output emission triggers an expensive render, it will block further processing until emission is done and likely will force subsequent updates to the main thread. To avoid that, we are separating emission from formula run.
