### PR TITLE
Implement batched event types.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/ActionBuilder.kt
+++ b/formula/src/main/java/com/instacart/formula/ActionBuilder.kt
@@ -73,7 +73,7 @@ abstract class ActionBuilder<out Input, State>(
      * @param transition A function that is invoked when [Action] emits an [Event].
      */
     abstract fun <Event> Action<Event>.onEventWithExecutionType(
-        executionType: Transition.ExecutionType,
+        executionType: Transition.ExecutionType?,
         transition: Transition<Input, State, Event>,
     )
 }

--- a/formula/src/main/java/com/instacart/formula/ActionFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/ActionFormula.kt
@@ -17,6 +17,11 @@ abstract class ActionFormula<Input : Any, Output : Any> : IFormula<Input, Output
      */
     abstract fun action(input: Input): Action<Output>
 
+    /**
+     * Transition execution type that will be used with this action.
+     */
+    open fun executionType(): Transition.ExecutionType? = null
+
     // Implements the common API used by the runtime.
     private val implementation: Formula<Input, Output, Output> = object : Formula<Input, Output, Output>() {
         override fun initialState(input: Input) = initialValue(input)
@@ -25,7 +30,8 @@ abstract class ActionFormula<Input : Any, Output : Any> : IFormula<Input, Output
             return Evaluation(
                 output = state,
                 actions = context.actions {
-                    action(input).onEvent {
+                    val executionType = executionType()
+                    action(input).onEventWithExecutionType(executionType) {
                         transition(it)
                     }
                 }

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula
 
+import com.instacart.formula.batch.BatchScheduler
 import kotlin.reflect.KClass
 
 /**
@@ -79,6 +80,25 @@ fun interface Transition<in Input, State, in Event> {
      * should be used for data events that might be expensive to process.
      */
     data object Background : ExecutionType()
+
+
+    /**
+     * NOTE: this is experimental feature, the APIs might change in the future.
+     *
+     * Batched execution type indicates that the event can be collected into a batch
+     * and processed as part of a group.
+     *
+     * @param scheduler Scheduler used to batch these events. The [BatchScheduler.key] will
+     * be used to group events together and [BatchScheduler.schedule] will be used to
+     * schedule the execution of the batch.
+     *
+     * TODO: add dropPrevious If true, will drop the previous event if a new event
+     * arrives before batch is processed.
+     */
+    data class Batched(
+        val scheduler: BatchScheduler, // TODO: make optional with default?
+//        val dropPrevious: Boolean = false,
+    ): ExecutionType()
 
     /**
      * Called when an [Event] happens and returns a [Result] object which can indicate a state

--- a/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
@@ -1,0 +1,42 @@
+package com.instacart.formula.batch
+
+import com.instacart.formula.FormulaRuntime
+import java.util.LinkedList
+import java.util.concurrent.atomic.AtomicBoolean
+
+internal class BatchImpl internal constructor(
+    private val runtime: FormulaRuntime<*, *>,
+    private val batchManager: BatchManager,
+    private val key: Any,
+) : BatchScheduler.Batch {
+
+    private val isScheduled = AtomicBoolean(false)
+    private val updates = LinkedList<() -> Unit>()
+
+    fun add(update: () -> Unit) {
+        updates.add(update)
+    }
+
+    override fun execute() {
+        /**
+         * We do not support batch modifications while processing which is why we removed the
+         * batch before processing. If [BatchManager.removeBatch] returns false, that indicates
+         * that batch was already processed.
+         */
+        if (batchManager.removeBatch(this)) {
+            runtime.executeBatch {
+                for (update in updates) {
+                    update()
+                }
+            }
+        }
+    }
+
+    override fun key(): Any = key
+
+    fun scheduleIfNeeded(batchScheduler: BatchScheduler) {
+        if (isScheduled.compareAndSet(false, true)) {
+            batchScheduler.schedule(this)
+        }
+    }
+}

--- a/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
@@ -1,12 +1,11 @@
 package com.instacart.formula.batch
 
-import com.instacart.formula.FormulaRuntime
 import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class BatchImpl internal constructor(
-    private val runtime: FormulaRuntime<*, *>,
     private val batchManager: BatchManager,
+    private val executor: BatchManager.Executor,
     private val key: Any,
 ) : BatchScheduler.Batch {
 
@@ -24,11 +23,7 @@ internal class BatchImpl internal constructor(
          * that batch was already processed.
          */
         if (batchManager.removeBatch(this)) {
-            runtime.executeBatch {
-                for (update in updates) {
-                    update()
-                }
-            }
+            executor.executeBatch(updates)
         }
     }
 

--- a/formula/src/main/java/com/instacart/formula/batch/BatchManager.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchManager.kt
@@ -16,7 +16,17 @@ import java.util.concurrent.ConcurrentHashMap
  * schedule the execution of the batch. The [BatchScheduler] will keep a reference to the batch
  * until it is executed.
  */
-internal class BatchManager(private val runtime: FormulaRuntime<*, *>) {
+internal class BatchManager(private val batchExecutor: Executor) {
+
+    /**
+     * Responsible for executing batch of updates.
+     *
+     * @see [FormulaRuntime]
+     */
+    interface Executor {
+        fun executeBatch(updates: List<() -> Unit>)
+    }
+
     private var activeBatches: MutableMap<Any, BatchImpl>? = null
 
     fun add(batched: Transition.Batched, event: Any?, update: () -> Unit) {
@@ -42,7 +52,7 @@ internal class BatchManager(private val runtime: FormulaRuntime<*, *>) {
 
         val key = scheduler.key(event)
         return activeBatches.getOrPut(key) {
-            BatchImpl(runtime, this, key)
+            BatchImpl(this, batchExecutor, key)
         }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/batch/BatchManager.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchManager.kt
@@ -1,0 +1,48 @@
+package com.instacart.formula.batch
+
+import com.instacart.formula.FormulaRuntime
+import com.instacart.formula.Transition
+import com.instacart.formula.internal.SynchronizedUpdateQueue
+import java.util.concurrent.ConcurrentHashMap
+
+/**
+ * The BatchManager is initialized by [FormulaRuntime] and scoped to [FormulaRuntime] root
+ * to manage batched events that happen in that formula tree. When an event marked
+ * with [Transition.Batched] arrives:
+ * - If we are already processing, we will process the event immediately without batching
+ * - Otherwise, we will check if there already exists a batch matching [BatchScheduler.key]. If one
+ * exists, we will add the event to that batch.
+ * - If no batch exists, we will initialize the batch and call [BatchScheduler.schedule] to
+ * schedule the execution of the batch. The [BatchScheduler] will keep a reference to the batch
+ * until it is executed.
+ */
+internal class BatchManager(private val runtime: FormulaRuntime<*, *>) {
+    private var activeBatches: MutableMap<Any, BatchImpl>? = null
+
+    fun add(batched: Transition.Batched, event: Any?, update: () -> Unit) {
+        val batch = synchronized(this) {
+            initOrGetBatch(batched.scheduler, event).apply {
+                // TODO: implement drop previous event!
+                add(update)
+            }
+        }
+        batch.scheduleIfNeeded(batched.scheduler)
+    }
+
+    fun removeBatch(batch: BatchImpl): Boolean {
+        val batchImpl = synchronized(this) {
+            activeBatches?.remove(batch.key())
+        }
+        return batchImpl === batch
+    }
+
+    private fun initOrGetBatch(scheduler: BatchScheduler, event: Any?): BatchImpl {
+        val activeBatches = activeBatches ?: mutableMapOf()
+        this.activeBatches = activeBatches
+
+        val key = scheduler.key(event)
+        return activeBatches.getOrPut(key) {
+            BatchImpl(runtime, this, key)
+        }
+    }
+}

--- a/formula/src/main/java/com/instacart/formula/batch/BatchScheduler.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchScheduler.kt
@@ -1,0 +1,41 @@
+package com.instacart.formula.batch
+
+/**
+ * Controls how events are batched and executed.
+ */
+interface BatchScheduler {
+
+    /**
+     * The batch class defines a group of events that will be executed together. The
+     * [key] is used to group events together and [execute] will be called by [BatchScheduler]
+     * to execute them.
+     */
+    interface Batch {
+        /**
+         * Executes the events.
+         */
+        fun execute()
+
+        /**
+         * Key used to group events
+         */
+        fun key(): Any
+    }
+
+    /**
+     * Schedule the execution of a batch.
+     */
+    fun schedule(batch: Batch)
+
+    /**
+     * Defines the batch key.
+     */
+    fun key(event: Any?): Any
+
+    /**
+     * TODO: will allow to immediately execute certain events.
+     * - Take into account ordering issues if two events from same listener happen and one
+     * is batched while the other should be executed immediately.
+     */
+//     fun shouldBatch(event: Any?): Boolean = true
+}

--- a/formula/src/main/java/com/instacart/formula/batch/BatchScheduler.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchScheduler.kt
@@ -30,7 +30,7 @@ interface BatchScheduler {
     /**
      * Defines the batch key.
      */
-    fun key(event: Any?): Any
+    fun key(event: Any?): Any = this
 
     /**
      * TODO: will allow to immediately execute certain events.

--- a/formula/src/main/java/com/instacart/formula/batch/StateBatchScheduler.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/StateBatchScheduler.kt
@@ -1,0 +1,81 @@
+package com.instacart.formula.batch
+
+import kotlin.concurrent.getOrSet
+
+/**
+ * The StateBatchScheduler class helps batch global state updates that have many
+ * subscribers. Without batching, updating global state could cause multiple formula
+ * evaluations and produce multiple outputs that need to be processed. To enable
+ * state update batching, we need to know when the update is started and finished.
+ *
+ * An example of global state manager would be
+ * ```
+ * class MyGlobalStateStore {
+ *   private val globalStateRelay = BehaviorRelay.create<GlobalState>()
+ *   private val batchScheduler = StateBatchScheduler()
+ *
+ *   // Expose it, so that it can be used with [Transition.Batched]
+ *   fun batchScheduler(): BatchScheduler = batchScheduler
+ *
+ *   fun publishUpdate(state: GlobalState) {
+ *     // Wrap updates in `performUpdate`
+ *     batchScheduler.performUpdate { globalStateRelay.accept(state) }
+ *   }
+ * }
+ * ```
+ *
+ * The main assumption with [StateBatchScheduler] is that formula subscribers are notified on
+ * the same thread as [performUpdate] is called. The way batching of state updates works:
+ * - We set isUpdating to true
+ * - We update our state and notify all the subscribers
+ * - The formula subscribers would create a batch and collect all updates within it. Formula
+ * calls [StateBatchScheduler.schedule] to add set the batch for execution.
+ * - We set isUpdating to false
+ * - We execute all the pending batches.
+ */
+class StateBatchScheduler : BatchScheduler {
+    private val isUpdating = ThreadLocal<Boolean>()
+    private val threadLocalBatches = ThreadLocal<MutableSet<BatchScheduler.Batch>>()
+
+    fun performUpdate(update: () -> Unit) {
+        if (isUpdating.get() == true) {
+            // Re-entry!
+            update()
+            return
+        }
+
+        isUpdating.set(true)
+        update()
+        isUpdating.remove()
+
+        // Get collected batches
+        val batches: MutableSet<BatchScheduler.Batch>? = threadLocalBatches.get()
+        // Clear them from our state
+        threadLocalBatches.remove()
+
+        // Execute them
+        if (batches != null) {
+            for(batch in batches) {
+                batch.execute()
+            }
+        }
+    }
+
+    override fun schedule(batch: BatchScheduler.Batch) {
+        if (isUpdating.get() == true) {
+            val batches = threadLocalBatches.getOrSet { mutableSetOf() }
+            batches.add(batch)
+        } else {
+            // No active update, let's just execute it.
+            batch.execute()
+        }
+    }
+
+    override fun key(event: Any?): Any {
+        /**
+         * We use current thread as part of the batch key because one of the assumptions
+         * are that subscriber initializes the batch on the same thread as the update.
+         */
+        return Pair(Thread.currentThread(), this)
+    }
+}

--- a/formula/src/main/java/com/instacart/formula/internal/ActionBuilderImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ActionBuilderImpl.kt
@@ -32,7 +32,7 @@ internal class ActionBuilderImpl<out Input, State> internal constructor(
     }
 
     override fun <Event> Action<Event>.onEventWithExecutionType(
-        executionType: Transition.ExecutionType,
+        executionType: Transition.ExecutionType?,
         transition: Transition<Input, State, Event>
     ) {
         val stream = this

--- a/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
@@ -110,6 +110,7 @@ internal class ChildrenManager(
             val implementation = formula.implementation()
             FormulaManagerImpl(
                 queue = delegate.queue,
+                batchManager = delegate.batchManager,
                 delegate = delegate,
                 formula = implementation,
                 initialInput = input,

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -7,6 +7,7 @@ import com.instacart.formula.IFormula
 import com.instacart.formula.plugin.Inspector
 import com.instacart.formula.Snapshot
 import com.instacart.formula.Transition
+import com.instacart.formula.batch.BatchManager
 import com.instacart.formula.plugin.Dispatcher
 import java.util.LinkedList
 import kotlin.reflect.KClass
@@ -20,6 +21,7 @@ import kotlin.reflect.KClass
  */
 internal class FormulaManagerImpl<Input, State, Output>(
     val queue: SynchronizedUpdateQueue,
+    val batchManager: BatchManager,
     private val delegate: ManagerDelegate,
     private val formula: Formula<Input, State, Output>,
     initialInput: Input,
@@ -61,7 +63,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
      * Determines if we are executing within [run] block. Enables optimizations
      * such as performing [DeferredTransition] inline.
      */
-    private var isRunning: Boolean = false
+    internal var isRunning: Boolean = false
 
     /**
      * Pending transition queue which will be populated and executed within [run] function

--- a/formula/src/main/java/com/instacart/formula/internal/SynchronizedUpdateQueue.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SynchronizedUpdateQueue.kt
@@ -44,8 +44,7 @@ class SynchronizedUpdateQueue(
      */
     fun postUpdate(update: () -> Unit) {
         val currentThread = Thread.currentThread()
-        val owner = threadRunning.get()
-        if (owner == currentThread) {
+        if (isProcessingOnCurrentThread()) {
             // This indicates a nested update where an update triggers another update. Given we
             // are already thread gated, we can execute this update immediately without a need
             // for any extra synchronization.
@@ -64,6 +63,10 @@ class SynchronizedUpdateQueue(
             updateQueue.add(update)
         }
         tryToDrainQueue(currentThread)
+    }
+
+    fun isProcessingOnCurrentThread(): Boolean {
+        return threadRunning.get() == Thread.currentThread()
     }
 
     /**

--- a/formula/src/test/java/com/instacart/formula/batch/BatchTest.kt
+++ b/formula/src/test/java/com/instacart/formula/batch/BatchTest.kt
@@ -1,0 +1,130 @@
+package com.instacart.formula.batch
+
+import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.Transition
+import com.instacart.formula.test.TestCallback
+import org.junit.Test
+
+class BatchTest {
+
+    object SimpleBatchExecutor : BatchManager.Executor {
+        override fun executeBatch(updates: List<() -> Unit>) {
+            for (update in updates) {
+                update()
+            }
+        }
+    }
+
+    class SimpleBatchScheduler(
+        private val scheduledBatches: MutableList<BatchScheduler.Batch>,
+    ) : BatchScheduler {
+        override fun schedule(batch: BatchScheduler.Batch) {
+            scheduledBatches.add(batch)
+        }
+    }
+
+    @Test
+    fun `only one batch per key`() {
+        val scheduledBatches = mutableListOf<BatchScheduler.Batch>()
+        val batchScheduler = SimpleBatchScheduler(scheduledBatches)
+        val batchedType = Transition.Batched(batchScheduler)
+        val testAction = TestCallback()
+
+        val batchManager = BatchManager(SimpleBatchExecutor)
+        batchManager.add(batchedType, Unit, testAction)
+        batchManager.add(batchedType, Unit, testAction)
+        batchManager.add(batchedType, Unit, testAction)
+
+        // Only one batch
+        assertThat(scheduledBatches).hasSize(1)
+
+        val otherScheduler = SimpleBatchScheduler(scheduledBatches)
+        val otherBatch = Transition.Batched(otherScheduler)
+        batchManager.add(otherBatch, Unit, testAction)
+
+        // Two batches now since other scheduler was used
+        assertThat(scheduledBatches).hasSize(2)
+    }
+
+    @Test fun `can execute same batch only once`() {
+        val scheduledBatches = mutableListOf<BatchScheduler.Batch>()
+        val batchScheduler = SimpleBatchScheduler(scheduledBatches)
+        val batchedType = Transition.Batched(batchScheduler)
+        val testAction = TestCallback()
+
+        val batchManager = BatchManager(SimpleBatchExecutor)
+        batchManager.add(batchedType, Unit, testAction)
+        batchManager.add(batchedType, Unit, testAction)
+        batchManager.add(batchedType, Unit, testAction)
+
+
+        for (batch in scheduledBatches) {
+            batch.execute()
+            batch.execute()
+            batch.execute()
+            batch.execute()
+            batch.execute()
+        }
+
+        // Only three actions - each executed once
+        testAction.assertTimesCalled(3)
+    }
+
+    @Test fun `remove batch returns false if not initialized`() {
+        val batchManager = BatchManager(SimpleBatchExecutor)
+        val batch = BatchImpl(batchManager, SimpleBatchExecutor, Unit)
+        val removed = batchManager.removeBatch(batch)
+        assertThat(removed).isFalse()
+    }
+
+    @Test fun `state batch scheduler will execute batch if no update is in progress`() {
+        val batchScheduler = StateBatchScheduler()
+        val batchManager = BatchManager(SimpleBatchExecutor)
+        val testAction = TestCallback()
+
+        val executionType = Transition.Batched(batchScheduler)
+        batchManager.add(executionType, Unit, testAction)
+        batchManager.add(executionType, Unit, testAction)
+
+        testAction.assertTimesCalled(2)
+    }
+
+    @Test fun `state batch scheduler clears batches from previous run`() {
+        var executed = 0
+        val batch = object : BatchScheduler.Batch {
+            override fun execute() {
+                executed += 1
+            }
+
+            override fun key(): Any = Unit
+        }
+
+        val batchScheduler = StateBatchScheduler()
+        batchScheduler.performUpdate {
+            batchScheduler.schedule(batch)
+        }
+
+        // Single execution
+        assertThat(executed).isEqualTo(1)
+
+        // No batches scheduled
+        batchScheduler.performUpdate {  }
+
+        // No new updates
+        assertThat(executed).isEqualTo(1)
+    }
+
+    @Test fun `state manager runs re-entrant update immediately`() {
+        val order = mutableListOf<Int>()
+        val batchScheduler = StateBatchScheduler()
+        batchScheduler.performUpdate {
+            order.add(1)
+            batchScheduler.performUpdate {
+                order.add(2)
+            }
+            order.add(3)
+        }
+
+        assertThat(order).containsExactly(1, 2, 3).inOrder()
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/types/ActionDelegateFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/ActionDelegateFormula.kt
@@ -13,7 +13,7 @@ class ActionDelegateFormula : Formula<ActionDelegateFormula.Input, Int, Int>() {
     /**
      * Allows us to define a custom action.
      */
-    interface DelegateAction {
+    fun interface DelegateAction {
         fun ActionBuilder<Input, Int>.runAction()
     }
 

--- a/formula/src/test/java/com/instacart/formula/types/IncrementActionFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/IncrementActionFormula.kt
@@ -1,0 +1,36 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Snapshot
+import com.instacart.formula.StatelessFormula
+import com.instacart.formula.Transition
+import com.instacart.formula.test.Relay
+
+class IncrementActionFormula(
+    private val incrementRelay: Relay,
+    private val executionType: Transition.ExecutionType? = null,
+) : StatelessFormula<Unit, Int>() {
+
+    private val actionInput = ActionDelegateFormula.Input(
+        delegateAction = {
+            if (executionType == null) {
+                incrementRelay.action().onEvent {
+                    transition(state + 1)
+                }
+            } else {
+                incrementRelay.action().onEventWithExecutionType(executionType) {
+                    transition(state + 1)
+                }
+            }
+        },
+        onAction = {}
+    )
+
+    private val actionFormula = ActionDelegateFormula()
+
+    override fun Snapshot<Unit, Unit>.evaluate(): Evaluation<Int> {
+        return Evaluation(
+            output = context.child(actionFormula, actionInput)
+        )
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/types/TestStateBatchScheduler.kt
+++ b/formula/src/test/java/com/instacart/formula/types/TestStateBatchScheduler.kt
@@ -1,0 +1,32 @@
+package com.instacart.formula.types
+
+import com.instacart.formula.batch.BatchScheduler
+import com.instacart.formula.batch.StateBatchScheduler
+
+class TestStateBatchScheduler : BatchScheduler {
+    private val delegate = StateBatchScheduler()
+
+    private val activeUpdates = mutableSetOf<Any>()
+
+    val batchesOutsideOfScope = mutableListOf<BatchScheduler.Batch>()
+
+    fun performUpdate(event: Any?, update: () -> Unit) {
+        val key = key(event)
+        activeUpdates.add(key)
+        delegate.performUpdate(update)
+        activeUpdates.remove(key)
+    }
+
+    override fun schedule(batch: BatchScheduler.Batch) {
+        val key = batch.key()
+        if (!activeUpdates.contains(key)) {
+            batchesOutsideOfScope.add(batch)
+        }
+
+        delegate.schedule(batch)
+    }
+
+    override fun key(event: Any?): Any {
+        return delegate.key(event)
+    }
+}


### PR DESCRIPTION
## What

Adding functionality to Formula to support event batching. 
- There is a new transition type `Transition.Batched`
- There is a new `BatchScheduler` interface which defines when a batch of events is executed

It supports two primary use cases around event batching
- Relay state updates that affect multiple subscribers within the same formula tree
- Different types of parallel data events that we want to process in timed batches

### State updates
To handle state updates, we want to wait for all subscribers to be notified before we process the transition. We would use a simple `BatchScheduler` 
```kotlin
class MyGlobalStateManager {
    // Define this outside of evaluate, formula uses equality of batch scheduler to group updates. 
    val stateScheduler = StateBatchScheduler()

    fun publishUpdate(state: State) {
        stateScheduler.performUpdate { relay.accept(state) }
    }

    fun globalStateUpdates(): Observable<State> = ... 
}
```

The action definition would look like this
```kotlin
// Within action defintion, we use `Transition.Batched` with `stateScheduler`
val batched = Transition.Batched(globalStateManager.stateScheduler, dropPrevious = true)
RxAction.fromObservable { globalStateObservable }.onEventWithExecutionType(batched) { state ->
    // handle state update
} 
```

### Timed-based event batching
When handling multiple network requests in parallel, we might want to collect them for a specific duration and execute them in a batch. An example of how the batch scheduler would look like

```kotlin
val debounceBatchScheduler = object : BatchScheduler {
    fun schedule(batch: BatchScheduler.Batch) { 
        GlobalScope.launch { 
            delay(100) // Wait for 100ms
            batch.execute() // Execute the batch
        }
    }
}
```

The action definition would look like
```kotlin
val batched = Transition.Batched(debounceBatchScheduler)
RxAction.fromObservable { repo.fetchData() }.onEventWithExecutionType(batched) { state ->
    // handle state update
} 
```



 

