### PR TITLE
Fix stale transition bug when using dispatchers.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/internal/DeferredTransition.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/DeferredTransition.kt
@@ -1,7 +1,5 @@
 package com.instacart.formula.internal
 
-import com.instacart.formula.Transition
-
 /**
  * A deferred transition contains an [event] and a related [transition] which can
  * be executed using the [execute] function. If the formula is ready, it will be
@@ -11,11 +9,10 @@ import com.instacart.formula.Transition
  */
 class DeferredTransition<Input, State, EventT> internal constructor(
     private val listener: ListenerImpl<Input, State, EventT>,
-    private val transition: Transition<Input, State, EventT>,
     private val event: EventT,
 ) {
 
     fun execute() {
-        listener.snapshotImpl?.dispatch(transition, event)
+        listener.applyInternal(event)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
@@ -53,10 +53,7 @@ internal class SnapshotImpl<out Input, State> internal constructor(
     ): Listener<Event> {
         ensureNotRunning()
         val listener = listeners.initOrFindListener<Input, State, Event>(key, useIndex)
-        listener.manager = delegate
-        listener.snapshotImpl = this
-        listener.executionType = executionType
-        listener.transition = transition
+        listener.setDependencies(delegate, this, executionType, transition)
         return listener
     }
 


### PR DESCRIPTION
Fixing a bug where `DeferredTransition` can hold to a stale `transition` property if a state change happens while event is waiting to be dispatched. Instead, we should rely on the mutable property that lives in `ListenerImpl` 