### PR TITLE
Publish coroutine support

### DIFF
--- a/.buildscript/upload_archives.sh
+++ b/.buildscript/upload_archives.sh
@@ -4,6 +4,7 @@
 ./gradlew :formula-test:build -PreleaseBuild
 ./gradlew :formula-android-compose:build -PreleaseBuild
 ./gradlew :formula-lint:build -PreleaseBuild
+./gradlew :formula-coroutines:build -PreleaseBuild
 
 # Disabling parallelism and daemon sharing is required by the vanniktech maven publish plugin.
 # Without those, the artifacts will be split across multiple (invalid) staging repositories.

--- a/formula-coroutines/build.gradle.kts
+++ b/formula-coroutines/build.gradle.kts
@@ -3,6 +3,10 @@ plugins {
     id("kotlin")
 }
 
+apply {
+    from("$rootDir/.buildscript/configure-signing.gradle")
+}
+
 dependencies {
     implementation(libs.kotlin)
     implementation(libs.coroutines)


### PR DESCRIPTION
Coroutine support isn't currently being published: https://repo1.maven.org/maven2/com/instacart/formula/

I believe adding this script should be enough to get it publishing. 