### PR TITLE
Ensure event ordering with dispatching.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -94,7 +94,9 @@ class FormulaRuntime<Input : Any, Output : Any>(
     }
 
     fun onInput(input: Input) {
-        synchronizedUpdateQueue.postUpdate { onInputInternal(input) }
+        defaultDispatcher.dispatch {
+            synchronizedUpdateQueue.postUpdate { onInputInternal(input) }
+        }
     }
 
     private fun onInputInternal(input: Input) {

--- a/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ListenerImpl.kt
@@ -61,12 +61,9 @@ internal class ListenerImpl<Input, State, EventT>(val key: Any) : Listener<Event
 
     private fun executeWithDispatcher(dispatcher: Dispatcher, event: EventT) {
         val manager = manager ?: return
-
-        dispatcher.dispatch {
-            manager.queue.postUpdate {
-                val deferredTransition = DeferredTransition(this, event)
-                manager.onPendingTransition(deferredTransition)
-            }
+        manager.queue.postUpdate(dispatcher) {
+            val deferredTransition = DeferredTransition(this, event)
+            manager.onPendingTransition(deferredTransition)
         }
     }
 }

--- a/formula/src/main/java/com/instacart/formula/plugin/Dispatcher.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/Dispatcher.kt
@@ -10,6 +10,10 @@ interface Dispatcher {
         override fun dispatch(executable: () -> Unit) {
             executable()
         }
+
+        override fun isDispatchNeeded(): Boolean {
+            return false
+        }
     }
 
     /**
@@ -19,6 +23,11 @@ interface Dispatcher {
         override fun dispatch(executable: () -> Unit) {
             val delegate = FormulaPlugins.mainThreadDispatcher()
             delegate.dispatch(executable)
+        }
+
+        override fun isDispatchNeeded(): Boolean {
+            val delegate = FormulaPlugins.mainThreadDispatcher()
+            return delegate.isDispatchNeeded()
         }
     }
 
@@ -30,10 +39,20 @@ interface Dispatcher {
             val delegate = FormulaPlugins.backgroundThreadDispatcher()
             delegate.dispatch(executable)
         }
+
+        override fun isDispatchNeeded(): Boolean {
+            val delegate = FormulaPlugins.backgroundThreadDispatcher()
+            return delegate.isDispatchNeeded()
+        }
     }
 
     /**
      * Dispatches [executable] to a thread specified by the [Dispatcher].
      */
     fun dispatch(executable: () -> Unit)
+
+    /**
+     * Returns true if dispatching event is needed
+     */
+    fun isDispatchNeeded(): Boolean
 }

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -1674,9 +1674,9 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
 
         val formula = IncrementFormula()
         val subject = runtime.test(formula, Unit)
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1) // Input
         subject.output { onIncrement() }
-        globalDispatcher.assertCalled(1)
+        globalDispatcher.assertCalled(2) // Input + event
     }
 
     @Test fun `specify formula-level dispatcher`() {
@@ -1688,10 +1688,10 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
         val formula = IncrementFormula()
         val subject = runtime.test(formula, Unit, dispatcher = formulaDispatcher)
         globalDispatcher.assertCalled(0)
-        formulaDispatcher.assertCalled(0)
+        formulaDispatcher.assertCalled(1) // Input
         subject.output { onIncrement() }
         globalDispatcher.assertCalled(0)
-        formulaDispatcher.assertCalled(1)
+        formulaDispatcher.assertCalled(2) // Input + event
     }
 
     @Test fun `immediate execution type within callbackWithExecutionType overrides default dispatcher`() {
@@ -1701,9 +1701,9 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
 
         val formula = IncrementFormula(executionType = Transition.Immediate)
         val subject = runtime.test(formula, Unit)
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1) // Initial for input
         subject.output { onIncrement() }
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1) // Initial for input
     }
 
     @Test fun `immediate execution type within onEventWithExecutionType overrides default dispatcher`() {
@@ -1713,9 +1713,9 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
 
         val formula = EventCallbackFormula(executionType = Transition.Immediate)
         val subject = runtime.test(formula, Unit)
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1) // Initial for input
         subject.output { this.changeState("new state") }
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1)
     }
 
     @Test fun `background execution type within action overrides default dispatcher`() {
@@ -1726,7 +1726,7 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
         val formula = OnDataActionFormula(executionType = Transition.Background)
         val input = OnDataActionFormula.Input(0, onData = {})
         val subject = runtime.test(formula, input)
-        globalDispatcher.assertCalled(0)
+        globalDispatcher.assertCalled(1) // Once for input
         plugin.backgroundDispatcher.assertCalled(1)
     }
 

--- a/formula/src/test/java/com/instacart/formula/subjects/IncrementingDispatcher.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/IncrementingDispatcher.kt
@@ -12,6 +12,10 @@ class IncrementingDispatcher : Dispatcher {
         executable()
     }
 
+    override fun isDispatchNeeded(): Boolean {
+        return true
+    }
+
     fun assertCalled(times: Int) {
         Truth.assertThat(count.get()).isEqualTo(times)
     }

--- a/formula/src/test/java/com/instacart/formula/types/OnDataActionFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/types/OnDataActionFormula.kt
@@ -23,15 +23,8 @@ class OnDataActionFormula(
         return Evaluation(
             output = Unit,
             actions = context.actions {
-                val onData = Action.onData(input.data)
-                if (executionType == null) {
-                    onData.onEvent {
-                        transition { input.onData(it) }
-                    }
-                } else {
-                    onData.onEventWithExecutionType(executionType) {
-                        transition { input.onData(it) }
-                    }
+                Action.onData(input.data).onEventWithExecutionType(executionType) {
+                    transition { input.onData(it) }
                 }
             }
         )


### PR DESCRIPTION
### The problem
With dispatching, we introduced the possibility for events to arrive in an unexpected order. For example:
1. We start a formula on a background thread 
2. During the start, formula subscribes to a relay that emits an initial value 
3. This initial value needs to be dispatched to the main thread
4. Before dispatching completes, the relay emits another value already on the main thread

The following scenario leads us to process the new value before the initial value. So, if the new value is a content event and the initial value is a loading event, you will first set the state to content and then to loading which will lead to infinite loading bug in your feature. 

### The fix
To fix this problem, we need to keep a predictable order of the incoming events. Instead of dispatching `queue.postUpdate`, we will pass `dispatcher` to `SynchronizedUpdateQueue`. `SynchronizedUpdateQueue` will add the update to internal queue to keep event order and will dispatch request to process the queue. This way we maintain the update order while processing can happen on a different thread. 
