### PR TITLE
Fix a termination race-condition within formula test.

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -32,6 +32,8 @@ jobs:
         run: ./gradlew :formula-android:testRelease
       - name: Run Formula Android Instrumentation Tests
         run: ./gradlew :formula-android-tests:testRelease
+      - name: Run Formula Test Module tests
+        run: ./gradlew :formula-test:test
       - name: Run Formula Lint Tests
         run: ./gradlew :formula-lint:build
       - name: Generate Jacoco Report


### PR DESCRIPTION
## What
Fixing a bug in the formula test module where:
- Formula with "A" key is run
- Key A is terminated but side-effect is not executed yet
- New Key A is run which overwrites the previous Key A
- Termination side-effect occurs and removes new Key A 


To fix this problem, I've made a couple of changes
- Added a unique long identifier to ensure that termination only removes the appropriate key
- Moved the side-effect to be executed immediately.