### PR TITLE
Refactor TestFormula and key logic.

### DIFF
--- a/formula-test/src/main/java/com/instacart/formula/test/TestExtensions.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestExtensions.kt
@@ -40,8 +40,22 @@ fun <Input : Any, State : Any, Output : Any> withSnapshot(
     return observer.values().last()
 }
 
+/**
+ *
+ * Creates a test formula for a specific [IFormula] instance.
+ *
+ * ```kotlin
+ * class FakeUserFormula : UserFormula {
+ *      override val implementation = testFormula(
+ *          initialOutput = User(
+ *              name = "Fake user name",
+ *          )
+ *      )
+ * }
+ * ```
+ */
 fun <Input, Output> IFormula<Input, Output>.testFormula(
     initialOutput: Output,
 ): TestFormula<Input, Output> {
-    return TestFormula(initialOutput, key = { this.key(it) })
+    return TestFormula(this, initialOutput)
 }

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormula.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormula.kt
@@ -12,7 +12,7 @@ import java.util.concurrent.atomic.AtomicLong
  * Test formula is used to replace a real formula with a fake implementation. This allows you to:
  * - Verify that parent passes correct inputs. Take a look at [input].
  * - Verify that parent deals with output changes correctly. Take a look at [output]
- *
+ * - Verify how many instances of formula parent is running. Take a look at [assertRunningCount]
  *
  * ```kotlin
  * // To replace a real formula with a fake one, we need first define the interface

--- a/formula-test/src/main/java/com/instacart/formula/test/utils/RunningInstanceManager.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/utils/RunningInstanceManager.kt
@@ -1,0 +1,62 @@
+package com.instacart.formula.test.utils
+
+internal class RunningInstanceManager<Input, Output>(
+    private val formulaKeyFactory: (Input) -> Any?,
+) {
+    data class State<Input, Output>(
+        val key: Any?,
+        val inputs: List<Input>,
+        val output: Output,
+        val onNewOutput: (Output) -> Unit,
+    )
+
+    // Uses identifier as key that is generated within [initialState]
+    private val runningInstanceStates = mutableMapOf<Long, State<Input, Output>>()
+
+    fun onEvaluate(
+        uniqueIdentifier: Long,
+        input: Input,
+        output: Output,
+        onNewOutput: (Output) -> Unit,
+    ) {
+        val currentValue = runningInstanceStates[uniqueIdentifier]
+        val newInputList = if (currentValue == null) {
+            listOf(input)
+        } else if (currentValue.inputs.last() == input) {
+            currentValue.inputs
+        } else {
+            currentValue.inputs + input
+        }
+
+        runningInstanceStates[uniqueIdentifier] = State(
+            key = formulaKeyFactory(input),
+            inputs = newInputList,
+            output = output,
+            onNewOutput = onNewOutput,
+        )
+    }
+
+    fun onTerminate(uniqueIdentifier: Long) {
+        runningInstanceStates.remove(uniqueIdentifier)
+    }
+
+    fun mostRecentInstance(): State<Input, Output> {
+        return requireNotNull(runningInstanceStates.values.lastOrNull()) {
+            "Formula is not running"
+        }
+    }
+
+    fun instanceByKey(key: Any?): State<Input, Output> {
+        return requireNotNull(runningInstanceStates.entries.firstOrNull { it.value.key == key }?.value) {
+            val existingKeys = runningInstanceStates.entries.map { it.value.key }
+            "Formula for $key is not running, there are $existingKeys running"
+        }
+    }
+
+    fun assertRunningCount(expected: Int) {
+        val count = runningInstanceStates.size
+        if (count != expected) {
+            throw AssertionError("Expected $expected running formulas, but there were $count instead")
+        }
+    }
+}

--- a/formula-test/src/test/java/com/instacart/formula/test/SimpleFormula.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/SimpleFormula.kt
@@ -8,14 +8,27 @@ interface SimpleFormula : IFormula<Input, Output> {
     data class Input(val inputId: String = "inputId")
     data class Output(val outputId: Int, val text: String)
 
-    override fun key(input: Input): Any? = "simple-formula-key"
+    override fun key(input: Input): Any? {
+        return if (useCustomKey) {
+            CUSTOM_KEY
+        } else {
+            super.key(input)
+        }
+    }
+
+    abstract val useCustomKey: Boolean
+
+    companion object {
+        const val CUSTOM_KEY = "simple-formula-key"
+    }
 }
 
 class TestSimpleFormula(
     private val initialOutput: Output = Output(
         outputId = 0,
         text = "",
-    )
+    ),
+    override val useCustomKey: Boolean = true,
 ) : SimpleFormula {
     override val implementation = testFormula(
         initialOutput = initialOutput,

--- a/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
@@ -1,5 +1,6 @@
 package com.instacart.formula.test
 
+import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import junit.framework.Assert.fail
 import org.junit.Test
@@ -135,6 +136,48 @@ class TestFormulaTest {
         formula.implementation.input(key = "simple-formula-key") {
             assertThat(this).isEqualTo(myInput)
         }
+    }
+
+    @Test fun `mostRecentInput returns last input passed by parent`() {
+        val inputA = SimpleFormula.Input("a")
+        val inputB = SimpleFormula.Input("b")
+        val formula = TestSimpleFormula()
+        formula.test().input(inputA).input(inputB)
+
+        val mostRecentInput = formula.implementation.mostRecentInput()
+        assertThat(mostRecentInput).isEqualTo(inputB)
+    }
+
+    @Test fun `mostRecentInputs returns all inputs parent passed`() {
+        val inputA = SimpleFormula.Input("a")
+        val inputB = SimpleFormula.Input("b")
+        val formula = TestSimpleFormula()
+        formula.test().input(inputA).input(inputB)
+
+        assertThat(formula.implementation.mostRecentInputs()).containsExactly(
+            inputA, inputB
+        ).inOrder()
+    }
+
+    @Test fun `inputByKey returns last input passed by parent`() {
+        val inputA = SimpleFormula.Input("a")
+        val inputB = SimpleFormula.Input("b")
+        val formula = TestSimpleFormula()
+        formula.test().input(inputA).input(inputB)
+
+        val inputByKey = formula.implementation.inputByKey(SimpleFormula.CUSTOM_KEY)
+        assertThat(inputByKey).isEqualTo(inputB)
+    }
+
+    @Test fun `inputsByKey returns all inputs parent passed`() {
+        val inputA = SimpleFormula.Input("a")
+        val inputB = SimpleFormula.Input("b")
+        val formula = TestSimpleFormula()
+        formula.test().input(inputA).input(inputB)
+
+        assertThat(formula.implementation.inputsByKey(SimpleFormula.CUSTOM_KEY)).containsExactly(
+            inputA, inputB
+        ).inOrder()
     }
 
     @Test fun `default key is null`() {

--- a/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestFormulaTest.kt
@@ -13,9 +13,10 @@ class TestFormulaTest {
     }
 
     @Test fun `emits initial output when subscribed`() {
-        val formula = TestSimpleFormula()
+        val initialOutput = SimpleFormula.Output(100, "random")
+        val formula = TestSimpleFormula(initialOutput)
         formula.test().input(SimpleFormula.Input()).output {
-            assertThat(this).isEqualTo(formula.implementation.initialOutput())
+            assertThat(this).isEqualTo(initialOutput)
         }
     }
 
@@ -134,5 +135,17 @@ class TestFormulaTest {
         formula.implementation.input(key = "simple-formula-key") {
             assertThat(this).isEqualTo(myInput)
         }
+    }
+
+    @Test fun `default key is null`() {
+        val formula = TestSimpleFormula(useCustomKey = false)
+        val key = formula.key(SimpleFormula.Input())
+        assertThat(key).isNull()
+    }
+
+    @Test fun `custom key is applied correctly`() {
+        val formula = TestSimpleFormula(useCustomKey = true)
+        val key = formula.key(SimpleFormula.Input())
+        assertThat(key).isEqualTo(SimpleFormula.CUSTOM_KEY)
     }
 }

--- a/formula/src/main/java/com/instacart/formula/StatelessFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/StatelessFormula.kt
@@ -37,13 +37,4 @@ abstract class StatelessFormula<Input, Output> : IFormula<Input, Output> {
      * All side-effects should happen as part of event listeners or [actions][Evaluation.actions].
      */
      abstract fun Snapshot<Input, Unit>.evaluate(): Evaluation<Output>
-
-    /**
-     * A unique identifier used to distinguish formulas of the same type.
-     *
-     * ```
-     * override fun key(input: ItemInput) = input.itemId
-     * ```
-     */
-    override fun key(input: Input): Any? = null
 }


### PR DESCRIPTION
There are a couple of changes around this PR
- Making `TestFormula` into a final class constructed via `testFormula` extension. 
- Fixing issues with `TestFormula` key resolution
- Adding the ability to get all inputs instead of only the most recent one.
- Documentation around `TestFormula` usage.
- Moving some of the internal test formula logic into `RunningInstanceManager`