### PR TITLE
Rename FragmentStoreBuilder to FeaturesBuilder.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@
 - Enable fine-grained control of dispatching via `Plugin.defaultDispatcher`, `RuntimeConfig.defaultDispatcher`, `Transition.ExecutionType` and `Effect.Type`.
 - Remove `RxStream` type alias.
 - Replace `implementation` function with a value
-- Removed `FlowFactory` and `Flow`
+- **Breaking**: Removed `FlowFactory` and `Flow`
+- **Breaking**: Replace `FragmentStoreBuilder` with `FeaturesBuilder`
 
 ## [0.7.1] - June 28, 2022
 - **Breaking**: Rename `FragmentBindingBuilder` to `FragmentStoreBuilder`

--- a/docs/Formula-Android.md
+++ b/docs/Formula-Android.md
@@ -215,9 +215,11 @@ class MyApp : Application() {
         
         FormulaAndroid.init(this) {
             activity(MyActivity::class) {
-                store(MyActivityComponent(this)) {
-                    bind(CounterFeatureFactory())
-                }
+                ActivityStore(
+                    fragmentStore = FragmentFlowStore.init(MyActivityComponent(this)) {
+                        bind(CounterFeatureFactory())
+                    }
+                )
             }
         }
     }
@@ -357,9 +359,11 @@ Now that we have our dependencies configured, let's bind the flow factory to our
 val appComponent = AppComponent()
 FormulaAndroid.init(this) {
     activity(MyActivity::class) {
-        store(appComponent) {
-            bind(AuthFlowFactory())
-        }
+        ActivityStore(
+            fragmentStore = FragmentFlowStore.init(appComponent) {
+                bind(AuthFlowFactory())
+            }
+        )
     }
 }
 ```
@@ -393,7 +397,7 @@ class MyApp : Application() {
         FormulaAndroid.init(this) {
             activity<MyActivity> {
             
-                store(
+                ActivityStore(
                     streams = {
                         // You can subscribe to your RxJava streams here.
                         val timerState =  Observable
@@ -453,7 +457,7 @@ FormulaAndroid.init(this) {
         // This component will survive configuration changes.
         val activityComponent = appComponent.createMyActivityComponent()
         
-        store(
+        ActivityStore(
             configureActivity = {
                 // in this callback `this` is the instance of MyActivity
                 // so we can use it to inject dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -169,7 +169,7 @@ class MyApp : Application() {
         
     FormulaAndroid.init(this) {
       activity<MyActivity> {
-        store(
+        ActivityStore(
           streams = {
             val formula = CounterFormula()
             update(formula.toObservable(), MyActivity::render)

--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityLifecycleEventTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityLifecycleEventTest.kt
@@ -6,6 +6,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FormulaAppCompatActivity
 import org.junit.Before
 import org.junit.Rule
@@ -25,7 +26,7 @@ class ActivityLifecycleEventTest {
             FormulaAndroid.init(app) {
                 activity<TestActivity> {
                     events = mutableListOf()
-                    store(
+                    ActivityStore(
                         streams = {
                             activityLifecycleState().subscribe {
                                 events.add(it)

--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FormulaAppCompatActivity
 import com.jakewharton.rxrelay3.PublishRelay
 import org.junit.Before
@@ -35,7 +36,7 @@ class ActivityUpdateTest {
         initFormula = { app ->
             FormulaAndroid.init(app) {
                 activity<TestActivity> {
-                    store(
+                    ActivityStore(
                         streams = {
                             update(updateRelay, TestActivity::applyUpdate)
                         }

--- a/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTimingTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/ActivityUpdateTimingTest.kt
@@ -5,6 +5,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FormulaAppCompatActivity
 import io.reactivex.rxjava3.core.Observable
 import org.junit.Before
@@ -38,7 +39,7 @@ class ActivityUpdateTimingTest {
         initFormula = { app ->
             FormulaAndroid.init(app) {
                 activity<TestActivity> {
-                    store(
+                    ActivityStore(
                         streams = {
                             update(updateRelay, TestActivity::applyUpdate)
                         }

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
@@ -6,6 +6,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.android.Feature
 import com.instacart.formula.android.FeatureFactory
+import com.instacart.formula.android.FragmentFlowStore
 import com.instacart.formula.android.ViewFactory
 import com.instacart.formula.android.events.ActivityResult
 import com.instacart.formula.test.TestFragmentActivity
@@ -29,7 +30,7 @@ class FragmentAndroidEventTest {
                         configureActivity = {
                             initialContract = TestLifecycleKey()
                         },
-                        contracts =  {
+                        fragmentStore = FragmentFlowStore.init {
                             val featureFactory = object : FeatureFactory<Unit, TestLifecycleKey> {
                                 override fun initialize(dependencies: Unit, key: TestLifecycleKey): Feature {
                                     return Feature(

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentAndroidEventTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.Feature
 import com.instacart.formula.android.FeatureFactory
 import com.instacart.formula.android.FragmentFlowStore
@@ -26,9 +27,9 @@ class FragmentAndroidEventTest {
         initFormula = { app ->
             FormulaAndroid.init(app) {
                 activity<TestFragmentActivity> {
-                    store(
+                    ActivityStore(
                         configureActivity = {
-                            initialContract = TestLifecycleKey()
+                            it.initialContract = TestLifecycleKey()
                         },
                         fragmentStore = FragmentFlowStore.init {
                             val featureFactory = object : FeatureFactory<Unit, TestLifecycleKey> {

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -10,6 +10,7 @@ import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.android.FragmentFlowState
 import com.instacart.formula.android.FragmentKey
 import com.instacart.formula.android.BackCallback
+import com.instacart.formula.android.FragmentFlowStore
 import com.instacart.formula.test.TestKey
 import com.instacart.formula.test.TestKeyWithId
 import com.instacart.formula.test.TestFragmentActivity
@@ -49,7 +50,7 @@ class FragmentFlowRenderViewTest {
 
                             updateThreads.add(Thread.currentThread())
                         },
-                        contracts =  {
+                        fragmentStore = FragmentFlowStore.init {
                             bind(TestFeatureFactory<TestKey> { stateChanges(it) })
                             bind(TestFeatureFactory<TestKeyWithId> { stateChanges(it) })
                         }

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentFlowRenderViewTest.kt
@@ -7,6 +7,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FragmentFlowState
 import com.instacart.formula.android.FragmentKey
 import com.instacart.formula.android.BackCallback
@@ -40,10 +41,10 @@ class FragmentFlowRenderViewTest {
         initFormula = { app ->
             FormulaAndroid.init(app) {
                 activity<TestFragmentActivity> {
-                    store(
-                        configureActivity = {
-                            initialContract = TestKey()
-                            onPreCreated(this)
+                    ActivityStore(
+                        configureActivity = { activity ->
+                            activity.initialContract = TestKey()
+                            onPreCreated(activity)
                         },
                         onRenderFragmentState = { a, state ->
                             lastState = state

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
@@ -7,6 +7,7 @@ import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.android.FormulaFragment
 import com.instacart.formula.android.ActivityStoreContext
 import com.instacart.formula.android.FeatureFactory
+import com.instacart.formula.android.FragmentFlowStore
 import com.instacart.formula.android.FragmentKey
 import com.instacart.formula.test.TestKey
 import com.instacart.formula.test.TestKeyWithId
@@ -36,7 +37,7 @@ class FragmentLifecycleStateTest {
                         configureActivity = {
                             initialContract = TestKey()
                         },
-                        contracts =  {
+                        fragmentStore = FragmentFlowStore.init {
                             bind(featureFactory<TestKey>(this@activity))
                             bind(featureFactory<TestKeyWithId>(this@activity))
                         }

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
@@ -4,6 +4,7 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FormulaFragment
 import com.instacart.formula.android.ActivityStoreContext
 import com.instacart.formula.android.FeatureFactory
@@ -33,9 +34,9 @@ class FragmentLifecycleStateTest {
                     started = mutableListOf()
                     resumed = mutableListOf()
 
-                    store(
+                    ActivityStore(
                         configureActivity = {
-                            initialContract = TestKey()
+                            it.initialContract = TestKey()
                         },
                         fragmentStore = FragmentFlowStore.init {
                             bind(featureFactory<TestKey>(this@activity))

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleTest.kt
@@ -8,6 +8,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.android.Feature
 import com.instacart.formula.android.FeatureFactory
+import com.instacart.formula.android.FragmentFlowStore
 import com.instacart.formula.android.ViewFactory
 import com.instacart.formula.test.TestFragmentActivity
 import com.instacart.formula.test.TestFragmentLifecycleCallback
@@ -36,7 +37,7 @@ class FragmentLifecycleTest {
                         contract = TestLifecycleKey()
                         initialContract = contract
                     },
-                    contracts =  {
+                    fragmentStore = FragmentFlowStore.init {
                         val featureFactory = object : FeatureFactory<Unit, TestLifecycleKey> {
                             override fun initialize(dependencies: Unit, key: TestLifecycleKey): Feature {
                                 return Feature(

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleTest.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.test.core.app.ApplicationProvider
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.Feature
 import com.instacart.formula.android.FeatureFactory
 import com.instacart.formula.android.FragmentFlowStore
@@ -31,11 +32,11 @@ class FragmentLifecycleTest {
     @get:Rule val formulaRule = TestFormulaRule(initFormula = { app ->
         FormulaAndroid.init(app) {
             activity<TestFragmentActivity> {
-                store(
-                    configureActivity = {
+                ActivityStore(
+                    configureActivity = { activity ->
                         lifecycleCallback = TestFragmentLifecycleCallback()
                         contract = TestLifecycleKey()
-                        initialContract = contract
+                        activity.initialContract = contract
                     },
                     fragmentStore = FragmentFlowStore.init {
                         val featureFactory = object : FeatureFactory<Unit, TestLifecycleKey> {

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStore.kt
@@ -18,7 +18,7 @@ import io.reactivex.rxjava3.disposables.Disposable
  * @param onFragmentLifecycleEvent This is callback for when a fragment is added or removed.
  */
 class ActivityStore<Activity : FragmentActivity>(
-    val fragmentStore: FragmentFlowStore,
+    val fragmentStore: FragmentFlowStore = FragmentFlowStore.EMPTY,
     val streams: (StreamConfigurator<Activity>.() -> Disposable)? = null,
     val configureActivity: ((Activity) -> Unit)? = null,
     val onRenderFragmentState: ((Activity, FragmentFlowState) -> Unit)? = null,

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStore.kt
@@ -9,7 +9,7 @@ import io.reactivex.rxjava3.disposables.Disposable
  * navigation destination [com.instacart.formula.fragment.FragmentKey] to its state
  * management stream.
  *
- * @param contracts Fragment state management defined for this [Activity].
+ * @param fragmentStore Fragment state management defined for this [Activity].
  * @param streams This provides ability to configure arbitrary RxJava streams that survive
  *                configuration changes. Check [com.instacart.formula.android.StreamConfigurator] for utility methods.
  * @param configureActivity This is invoked as part of [com.instacart.formula.FormulaAndroid.onPreCreate]. You can
@@ -18,7 +18,7 @@ import io.reactivex.rxjava3.disposables.Disposable
  * @param onFragmentLifecycleEvent This is callback for when a fragment is added or removed.
  */
 class ActivityStore<Activity : FragmentActivity>(
-    val contracts: FragmentFlowStore,
+    val fragmentStore: FragmentFlowStore,
     val streams: (StreamConfigurator<Activity>.() -> Disposable)? = null,
     val configureActivity: ((Activity) -> Unit)? = null,
     val onRenderFragmentState: ((Activity, FragmentFlowState) -> Unit)? = null,

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
@@ -3,9 +3,7 @@ package com.instacart.formula.android
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import com.instacart.formula.android.events.ActivityResult
-import com.instacart.formula.android.events.FragmentLifecycleEvent
 import io.reactivex.rxjava3.core.Observable
-import io.reactivex.rxjava3.disposables.Disposable
 
 /**
  * This class provides context within which you can create [ActivityStore]. It provides
@@ -69,31 +67,4 @@ abstract class ActivityStoreContext<out Activity : FragmentActivity> {
      * it will do nothing.
      */
     abstract fun send(effect: Activity.() -> Unit)
-
-    /**
-     * Creates an [ActivityStore].
-     *
-     * @param configureActivity This is called when activity is created before view inflation. You can use this to
-     *                          configure / inject the activity.
-     * @param onRenderFragmentState This is called after [FragmentFlowState] is applied to UI.
-     * @param onFragmentLifecycleEvent This is called after each [FragmentLifecycleEvent].
-     * @param streams This provides ability to configure arbitrary RxJava streams that survive
-     *                configuration changes. Check [StreamConfigurator] for utility methods.
-     * @param fragmentStore [FragmentFlowStore] used to provide state management for individual screens.
-     */
-    fun <ActivityT : FragmentActivity> store(
-        configureActivity: (ActivityT.() -> Unit)? = null,
-        onRenderFragmentState: ((ActivityT, FragmentFlowState) -> Unit)? = null,
-        onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null,
-        streams: (StreamConfigurator<ActivityT>.() -> Disposable)? = null,
-        fragmentStore: FragmentFlowStore = FragmentFlowStore.EMPTY,
-    ): ActivityStore<ActivityT> {
-        return ActivityStore(
-            fragmentStore =  fragmentStore,
-            configureActivity = configureActivity,
-            onFragmentLifecycleEvent = onFragmentLifecycleEvent,
-            onRenderFragmentState = onRenderFragmentState,
-            streams = streams
-        )
-    }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
@@ -79,58 +79,21 @@ abstract class ActivityStoreContext<out Activity : FragmentActivity> {
      * @param onFragmentLifecycleEvent This is called after each [FragmentLifecycleEvent].
      * @param streams This provides ability to configure arbitrary RxJava streams that survive
      *                configuration changes. Check [StreamConfigurator] for utility methods.
-     * @param contracts [FragmentFlowStore] used to provide state management for individual screens.
+     * @param fragmentStore [FragmentFlowStore] used to provide state management for individual screens.
      */
     fun <ActivityT : FragmentActivity> store(
         configureActivity: (ActivityT.() -> Unit)? = null,
         onRenderFragmentState: ((ActivityT, FragmentFlowState) -> Unit)? = null,
         onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null,
         streams: (StreamConfigurator<ActivityT>.() -> Disposable)? = null,
-        contracts: FragmentFlowStore
+        fragmentStore: FragmentFlowStore = FragmentFlowStore.EMPTY,
     ): ActivityStore<ActivityT> {
         return ActivityStore(
-            contracts =  contracts,
+            fragmentStore =  fragmentStore,
             configureActivity = configureActivity,
             onFragmentLifecycleEvent = onFragmentLifecycleEvent,
             onRenderFragmentState = onRenderFragmentState,
             streams = streams
         )
-    }
-
-    /**
-     * Creates an [ActivityStore].
-     *
-     * @param configureActivity This is called when activity is created before view inflation. You can use this to
-     *                          configure / inject the activity.
-     * @param onRenderFragmentState This is called after [FragmentFlowState] is applied to UI.
-     * @param onFragmentLifecycleEvent This is called after each [FragmentLifecycleEvent].
-     * @param streams This provides ability to configure arbitrary RxJava streams that survive
-     *                configuration changes. Check [StreamConfigurator] for utility methods.
-     * @param contracts Builder method that configures [FragmentFlowStore] used to provide state management for individual screens.
-     */
-    inline fun <ActivityT : FragmentActivity> store(
-        noinline configureActivity: (ActivityT.() -> Unit)? = null,
-        noinline onRenderFragmentState: ((ActivityT, FragmentFlowState) -> Unit)? = null,
-        noinline onFragmentLifecycleEvent: ((FragmentLifecycleEvent) -> Unit)? = null,
-        noinline streams: (StreamConfigurator<ActivityT>.() -> Disposable)? = null,
-        crossinline contracts: FragmentStoreBuilder<Unit>.() -> Unit = {}
-    ): ActivityStore<ActivityT> {
-        return store(
-            configureActivity = configureActivity,
-            onRenderFragmentState = onRenderFragmentState,
-            onFragmentLifecycleEvent = onFragmentLifecycleEvent,
-            streams = streams,
-            contracts =  contracts(Unit, contracts)
-        )
-    }
-
-    /**
-     * Convenience method to to create a [FragmentFlowStore] with a [Component] instance.
-     */
-    inline fun <Component> contracts(
-        rootComponent: Component,
-        crossinline contracts: FragmentStoreBuilder<Component>.() -> Unit
-    ): FragmentFlowStore {
-        return FragmentFlowStore.init(rootComponent, contracts)
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/Feature.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/Feature.kt
@@ -8,7 +8,7 @@ import io.reactivex.rxjava3.core.Observable
  * and the [stateObservable] observable.
  *
  * To define a feature, we need to create a [FeatureFactory] for a specific [FragmentKey] type
- * and [bind][FragmentStoreBuilder.bind] it to the [FragmentFlowStore].
+ * and [bind][FeaturesBuilder.bind] it to the [FragmentFlowStore].
  *
  * Take a look at [FeatureFactory] for more information.
  */

--- a/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
@@ -26,7 +26,7 @@ package com.instacart.formula.android
  * }
  * ```
  *
- * Once we define a [FeatureFactory], we need to [bind][FragmentStoreBuilder.bind] it to a
+ * Once we define a [FeatureFactory], we need to [bind][FeaturesBuilder.bind] it to a
  * [FragmentFlowStore]. The fragment flow store will call [initialize] the first time
  * [FormulaFragment] with a new [Key] is attached. It will subscribe to the state management
  * and persist it across configuration changes.

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentFlowStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentFlowStore.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.android
 
 import com.instacart.formula.RuntimeConfig
 import com.instacart.formula.android.events.FragmentLifecycleEvent
+import com.instacart.formula.android.internal.Features
 import com.instacart.formula.android.internal.FragmentFlowStoreFormula
 import com.instacart.formula.android.utils.MainThreadDispatcher
 import com.instacart.formula.rxjava3.toObservable
@@ -14,18 +15,27 @@ class FragmentFlowStore @PublishedApi internal constructor(
     private val formula: FragmentFlowStoreFormula<*>,
 ) {
     companion object {
+        val EMPTY = init {  }
+
         inline fun init(
-            crossinline init: FragmentStoreBuilder<Unit>.() -> Unit
+            crossinline init: FeaturesBuilder<Unit>.() -> Unit
         ): FragmentFlowStore {
             return init(Unit, init)
         }
 
         inline fun <Component> init(
             rootComponent: Component,
-            crossinline contracts: FragmentStoreBuilder<Component>.() -> Unit
+            crossinline init: FeaturesBuilder<Component>.() -> Unit
         ): FragmentFlowStore {
-            val bindings = FragmentStoreBuilder.build(contracts)
-            val formula = FragmentFlowStoreFormula(rootComponent, bindings)
+            val features = FeaturesBuilder.build(init)
+            return init(rootComponent, features)
+        }
+
+        fun <Component> init(
+            component: Component,
+            features: Features<Component>
+        ): FragmentFlowStore {
+            val formula = FragmentFlowStoreFormula(component, features.bindings)
             return FragmentFlowStore(formula)
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -43,11 +43,11 @@ internal class ActivityManager<Activity : FragmentActivity>(
             activity = activity,
             fragmentEnvironment = environment,
             onLifecycleEvent = {
-                store.contracts.onLifecycleEffect(it)
+                store.fragmentStore.onLifecycleEffect(it)
                 store.onFragmentLifecycleEvent?.invoke(it)
             },
             onLifecycleState = delegate::updateFragmentLifecycleState,
-            onFragmentViewStateChanged = store.contracts::onVisibilityChanged
+            onFragmentViewStateChanged = store.fragmentStore::onVisibilityChanged
         )
     }
 
@@ -108,7 +108,7 @@ internal class ActivityManager<Activity : FragmentActivity>(
 
     private fun subscribeToFragmentStateChanges(): Disposable {
         return store
-            .contracts
+            .fragmentStore
             .state(environment)
             .subscribe(delegate.fragmentFlowStateRelay::accept)
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureBinding.kt
@@ -6,7 +6,7 @@ import com.instacart.formula.android.FragmentKey
 /**
  * Defines how a specific key should be bound to its [FeatureFactory]
  */
-class FeatureBinding<in Component, Key : FragmentKey>(
+class FeatureBinding<in Dependencies, Key : FragmentKey>(
     val type: Class<Key>,
-    val feature: FeatureFactory<Component, Key>,
+    val feature: FeatureFactory<Dependencies, Key>,
 )

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/Features.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/Features.kt
@@ -1,0 +1,5 @@
+package com.instacart.formula.android.internal
+
+class Features<in Dependencies>(
+    val bindings: List<FeatureBinding<Dependencies, *>>,
+)

--- a/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
@@ -18,7 +18,7 @@ class ActivityStoreFactoryTest {
             environment = FragmentEnvironment(),
             activities = {
                 activity(FakeActivity::class) {
-                    store()
+                    ActivityStore()
                 }
             }
         )

--- a/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
@@ -18,7 +18,7 @@ class ActivityStoreFactoryTest {
             environment = FragmentEnvironment(),
             activities = {
                 activity(FakeActivity::class) {
-                    store { }
+                    store()
                 }
             }
         )

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.instacart.formula.FormulaAndroid
 import com.instacart.formula.android.FragmentEnvironment
+import com.instacart.formula.android.FragmentFlowStore
 
 class StopwatchApp : Application() {
 
@@ -20,7 +21,7 @@ class StopwatchApp : Application() {
             activities = {
                 activity<StopwatchActivity> {
                     store(
-                        contracts = contracts(Unit) {
+                        fragmentStore = FragmentFlowStore.init(Unit) {
                             bind(StopwatchFeatureFactory())
                         }
                     )

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
@@ -3,6 +3,7 @@ package com.instacart.formula.compose.stopwatch
 import android.app.Application
 import android.util.Log
 import com.instacart.formula.FormulaAndroid
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.FragmentFlowStore
 
@@ -20,7 +21,7 @@ class StopwatchApp : Application() {
             ),
             activities = {
                 activity<StopwatchActivity> {
-                    store(
+                    ActivityStore(
                         fragmentStore = FragmentFlowStore.init(Unit) {
                             bind(StopwatchFeatureFactory())
                         }

--- a/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
@@ -5,6 +5,7 @@ import android.util.Log
 import com.examples.todoapp.tasks.TaskListFeatureFactory
 import com.instacart.formula.FormulaAndroid
 import com.instacart.formula.android.FragmentEnvironment
+import com.instacart.formula.android.FragmentFlowStore
 
 class TodoApp : Application() {
 
@@ -23,7 +24,7 @@ class TodoApp : Application() {
                     val component = TodoAppComponent(this)
 
                     store(
-                        contracts = contracts(component) {
+                        fragmentStore = FragmentFlowStore.init(component) {
                             bind(TaskListFeatureFactory())
                         }
                     )

--- a/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.util.Log
 import com.examples.todoapp.tasks.TaskListFeatureFactory
 import com.instacart.formula.FormulaAndroid
+import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.FragmentFlowStore
 
@@ -23,7 +24,7 @@ class TodoApp : Application() {
                 activity<TodoActivity> {
                     val component = TodoAppComponent(this)
 
-                    store(
+                    ActivityStore(
                         fragmentStore = FragmentFlowStore.init(component) {
                             bind(TaskListFeatureFactory())
                         }


### PR DESCRIPTION
## What

- Rename `FragmentStoreBuilder` to `FeaturesBuilder`
- Make `FeaturesBuilder.build` non-internal. This allows us to build `Features` list outside of `FragmentFlowStore`
- Rename `contracts` parameters to `fragmentStore`
