### PR TITLE
Refactor FeatureFactory public API using Params.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 - **Breaking**: Removed `FlowFactory` and `Flow`
 - **Breaking**: Replace `FragmentStoreBuilder` with `FeaturesBuilder`
 - **Breaking**: Rename `FragmentFlowStore` to `FragmentStore`, `FragmentState` to `FragmentOutput`, `FragmentFlowState` to `FragmentState`
+- **Breaking**: Making `FeatureFactory` into an abstract class and modifying the `initialize` API to use `Params` wrapper type
 
 ## [0.7.1] - June 28, 2022
 - **Breaking**: Rename `FragmentBindingBuilder` to `FragmentStoreBuilder`

--- a/formula-android-tests/src/test/java/com/instacart/formula/TestFeatureFactory.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/TestFeatureFactory.kt
@@ -9,9 +9,8 @@ import io.reactivex.rxjava3.core.Observable
 class TestFeatureFactory<Key : FragmentKey>(
     private val render: (FragmentKey, Any) -> Unit = { _, _ -> },
     private val state: (Key) -> Observable<Any>,
-
-) : FeatureFactory<Unit, Key> {
-    override fun initialize(dependencies: Unit, key: Key): Feature {
+) : FeatureFactory<Unit, Key>() {
+    override fun Params.initialize(): Feature {
         return Feature(
             state = state(key),
             viewFactory = TestViewFactory { _, value ->

--- a/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
@@ -35,10 +35,22 @@ package com.instacart.formula.android
  * @param Key a type of fragment key that is used to identify this feature.
  *
  */
-interface FeatureFactory<in Dependencies, in Key : FragmentKey> {
+abstract class FeatureFactory<in Dependencies, in Key : FragmentKey> {
+
+    inner class Params(
+        val dependencies: @UnsafeVariance Dependencies,
+        val key: @UnsafeVariance Key,
+    )
+
+    /**
+     * Initializes the [Feature] using [Params] provided.
+     */
+    abstract fun Params.initialize(): Feature
 
     /**
      * Initializes state observable and a view factory for a specific [key].
      */
-    fun initialize(dependencies: Dependencies, key: Key): Feature
+    fun initialize(dependencies: Dependencies, key: Key): Feature {
+        return Params(dependencies, key).initialize()
+    }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/MappedFeatureFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/MappedFeatureFactory.kt
@@ -8,8 +8,8 @@ import com.instacart.formula.android.FragmentKey
 internal class MappedFeatureFactory<Component, Dependencies, Key : FragmentKey>(
     private val delegate: FeatureFactory<Dependencies, Key>,
     private val toDependencies: (Component) -> Dependencies,
-) : FeatureFactory<Component, Key> {
-    override fun initialize(dependencies: Component, key: Key): Feature {
+) : FeatureFactory<Component, Key>() {
+    override fun Params.initialize(): Feature {
         return delegate.initialize(
             dependencies = toDependencies(dependencies),
             key = key,

--- a/formula-android/src/test/java/com/instacart/formula/android/FragmentStoreTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/FragmentStoreTest.kt
@@ -87,8 +87,8 @@ class FragmentStoreTest {
     }
 
     @Test fun `bind feature factory with to dependencies defined`() {
-        val myFeatureFactory = object : FeatureFactory<String, MainKey> {
-            override fun initialize(dependencies: String, key: MainKey): Feature {
+        val myFeatureFactory = object : FeatureFactory<String, MainKey>() {
+            override fun Params.initialize(): Feature {
                 return TestUtils.feature(
                     stateValue = dependencies
                 )
@@ -182,8 +182,8 @@ class FragmentStoreTest {
     @Test fun `store returns failure event when feature factory initialization throws an error`() {
         val expectedError = RuntimeException("something happened")
         val store = FragmentStore.init(FakeComponent()) {
-            val featureFactory = object : FeatureFactory<FakeComponent, MainKey> {
-                override fun initialize(dependencies: FakeComponent, key: MainKey): Feature {
+            val featureFactory = object : FeatureFactory<FakeComponent, MainKey>() {
+                override fun Params.initialize(): Feature {
                     throw expectedError
                 }
             }
@@ -209,8 +209,8 @@ class FragmentStoreTest {
         val stateSubject = PublishSubject.create<Any>()
 
         val store = FragmentStore.init {
-            val featureFactory = object : FeatureFactory<Any, MainKey> {
-                override fun initialize(dependencies: Any, key: MainKey): Feature {
+            val featureFactory = object : FeatureFactory<Any, MainKey>() {
+                override fun Params.initialize(): Feature {
                     return Feature(
                         state = stateSubject,
                         viewFactory = TestViewFactory(),
@@ -248,8 +248,8 @@ class FragmentStoreTest {
         val stateSubject = PublishSubject.create<Any>()
 
         val store = FragmentStore.init {
-            val featureFactory = object : FeatureFactory<Any, MainKey> {
-                override fun initialize(dependencies: Any, key: MainKey): Feature {
+            val featureFactory = object : FeatureFactory<Any, MainKey>() {
+                override fun Params.initialize(): Feature {
                     return Feature(
                         state = stateSubject,
                         viewFactory = TestViewFactory(),
@@ -293,8 +293,8 @@ class FragmentStoreTest {
 
     @Test fun `fragment store visible output`() {
         val store = FragmentStore.init {
-            val featureFactory = object : FeatureFactory<Any, MainKey> {
-                override fun initialize(dependencies: Any, key: MainKey): Feature {
+            val featureFactory = object : FeatureFactory<Any, MainKey>() {
+                override fun Params.initialize(): Feature {
                     return Feature(
                         state = Observable.just("value"),
                         viewFactory = TestViewFactory(),
@@ -360,8 +360,8 @@ class FragmentStoreTest {
     private fun FragmentKey.asAddedEvent() = FragmentLifecycleEvent.Added(FragmentId("", this))
     private fun FragmentKey.asRemovedEvent() = FragmentLifecycleEvent.Removed(FragmentId("", this))
 
-    class TestFeatureFactory<FragmentKeyT : FragmentKey>: FeatureFactory<FakeComponent, FragmentKeyT> {
-        override fun initialize(dependencies: FakeComponent, key: FragmentKeyT): Feature {
+    class TestFeatureFactory<FragmentKeyT : FragmentKey>: FeatureFactory<FakeComponent, FragmentKeyT>() {
+        override fun Params.initialize(): Feature {
             return Feature(
                 state = dependencies.state(key),
                 viewFactory = TestViewFactory()

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFeatureFactory.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchFeatureFactory.kt
@@ -23,8 +23,8 @@ import com.instacart.formula.android.compose.ComposeViewFactory
 import com.instacart.formula.invoke
 import com.instacart.formula.rxjava3.toObservable
 
-class StopwatchFeatureFactory : FeatureFactory<Any, StopwatchKey> {
-    override fun initialize(dependencies: Any, key: StopwatchKey): Feature {
+class StopwatchFeatureFactory : FeatureFactory<Any, StopwatchKey>() {
+    override fun Params.initialize(): Feature {
         return Feature(
             state = StopwatchFormula().toObservable(),
             viewFactory = StopwatchViewFactory()

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListFeatureFactory.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListFeatureFactory.kt
@@ -9,13 +9,13 @@ import com.instacart.formula.android.LayoutViewFactory
 import com.instacart.formula.android.ViewInstance
 import com.instacart.formula.rxjava3.toObservable
 
-class TaskListFeatureFactory : FeatureFactory<TaskListFeatureFactory.Dependencies, TaskListKey> {
+class TaskListFeatureFactory : FeatureFactory<TaskListFeatureFactory.Dependencies, TaskListKey>() {
     interface Dependencies {
         fun taskRepo(): TaskRepo
         fun taskListInput(): TaskListFormula.Input
     }
 
-    override fun initialize(dependencies: Dependencies, key: TaskListKey): Feature {
+    override fun Params.initialize(): Feature {
         // Note: we could create our own internal dagger component here using the dependencies.
         val formula = TaskListFormula(dependencies.taskRepo())
         return Feature(

--- a/test-utils/android/src/main/java/com/instacart/testutils/android/NoOpFeatureFactory.kt
+++ b/test-utils/android/src/main/java/com/instacart/testutils/android/NoOpFeatureFactory.kt
@@ -8,8 +8,8 @@ import io.reactivex.rxjava3.core.Observable
 
 class NoOpFeatureFactory<FragmentKeyT : FragmentKey>(
     private val viewFactory: ViewFactory<FragmentKeyT> = TestViewFactory(),
-) : FeatureFactory<Unit, FragmentKeyT> {
-    override fun initialize(dependencies: Unit, key: FragmentKeyT): Feature {
+) : FeatureFactory<Unit, FragmentKeyT>() {
+    override fun Params.initialize(): Feature {
         return Feature(
             state = Observable.empty(),
             viewFactory = viewFactory,


### PR DESCRIPTION
## What
I'm wrapping the `dependencies` and `key` into a `Params` object and updating `FeatureFactory.initialize` to get it via the extension function receiver type `Params.initialize(): Feature`.

Feature factory initialization changes from
```kotlin
override fun initialize(dependencies: Unit, key: Key): Feature
```
to 
```kotlin
override fun Params.initialize(): Feature
```

### Why
We need to pass `FragmentId` or something equivalent to the `FeatureFactory`. This change requires us to introduce a new parameter that would break existing usages. Instead of just adding a new parameter, I'm refactoring the way this public API works which will enable us to modify `Params` object in the future without breaking the usages.