### PR TITLE
Change Gradle depedency on site to be Kotlin friendly

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Add the library to your list of dependencies:
 
 ```groovy
 dependencies {
-    implementation 'com.instacart.formula:formula-rxjava3:0.7.1'
-    implementation 'com.instacart.formula:formula-android:0.7.1'
+    implementation("com.instacart.formula:formula-rxjava3:0.7.1")
+    implementation("com.instacart.formula:formula-android:0.7.1")
 }
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -190,8 +190,8 @@ Add the library to your list of dependencies:
 
 ```groovy
 dependencies {
-    implementation 'com.instacart.formula:formula-rxjava3:0.7.1'
-    implementation 'com.instacart.formula:formula-android:0.7.1'
+    implementation("com.instacart.formula:formula-rxjava3:0.7.1")
+    implementation("com.instacart.formula:formula-android:0.7.1")
 }
 ```
 


### PR DESCRIPTION
This allows users of both `build.gradle` and `build.gradle.kts` to be able to copy/paste this in without modification.