### PR TITLE
Provide global action error handling.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
@@ -16,13 +16,13 @@ class FeatureObservableAction(
 
     override fun key(): Any = fragmentId
 
-    override fun start(scope: CoroutineScope, send: (Any) -> Unit): Cancelable {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Any>): Cancelable {
         val observable = feature.stateObservable.onErrorResumeNext {
             fragmentEnvironment.onScreenError(fragmentId.key, it)
             Observable.empty()
         }
 
-        val disposable = observable.subscribe(send)
+        val disposable = observable.subscribe(emitter::onEvent, emitter::onError)
         return Cancelable(disposable::dispose)
     }
 }

--- a/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxAction.kt
+++ b/formula-rxjava3/src/main/java/com/instacart/formula/rxjava3/RxAction.kt
@@ -49,8 +49,8 @@ interface RxAction<Event : Any> : Action<Event> {
 
     fun observable(): Observable<Event>
 
-    override fun start(scope: CoroutineScope, send: (Event) -> Unit): Cancelable? {
-        val disposable = observable().subscribe(send)
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Event>): Cancelable? {
+        val disposable = observable().subscribe(emitter::onEvent, emitter::onError)
         return Cancelable(disposable::dispose)
     }
 }

--- a/formula-rxjava3/src/test/java/com/instacart/formula/rxjava3/RxActionTest.kt
+++ b/formula-rxjava3/src/test/java/com/instacart/formula/rxjava3/RxActionTest.kt
@@ -1,5 +1,7 @@
 package com.instacart.formula.rxjava3
 
+import com.google.common.truth.Truth
+import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.test.test
 import com.jakewharton.rxrelay3.PublishRelay
 import io.reactivex.rxjava3.core.Observable
@@ -28,5 +30,15 @@ class RxActionTest {
             relay.accept("b")
             assertValues("a")
         }
+    }
+
+    @Test fun `fromObservable emits error`() = runTest {
+        val error = RuntimeException("Test exception")
+        val result = kotlin.runCatching {
+            RxAction.fromObservable { Observable.error<String>(error) }.test {}
+        }
+        assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo(
+            "Expected no errors, but got: [java.lang.RuntimeException: Test exception]"
+        )
     }
 }

--- a/formula-test/src/test/java/com/instacart/formula/test/TestActionObserverTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestActionObserverTest.kt
@@ -47,7 +47,10 @@ class TestActionObserverTest {
     @Test fun `cancel invokes cancelable`() = runTest {
         var cancelableCalled = 0
         val action = object : Action<String> {
-            override fun start(scope: CoroutineScope, send: (String) -> Unit): Cancelable {
+            override fun start(
+                scope: CoroutineScope,
+                emitter: Action.Emitter<String>
+            ): Cancelable {
                 return Cancelable { cancelableCalled += 1 }
             }
 
@@ -61,9 +64,9 @@ class TestActionObserverTest {
     }
 
     private fun multipleValueStream() = object : Action<Int> {
-        override fun start(scope: CoroutineScope, send: (Int) -> Unit): Cancelable? {
-            send(1)
-            send(2)
+        override fun start(scope: CoroutineScope, emitter: Action.Emitter<Int>): Cancelable? {
+            emitter.onEvent(1)
+            emitter.onEvent(2)
             return null
         }
 

--- a/formula/src/main/java/com/instacart/formula/Action.kt
+++ b/formula/src/main/java/com/instacart/formula/Action.kt
@@ -178,6 +178,11 @@ interface Action<Event> {
         }
     }
 
+    interface Emitter<Event> {
+        fun onEvent(event: Event)
+        fun onError(throwable: Throwable)
+    }
+
     /**
      * Formula runtime calls this method to initialize an [Action] the first time it is returned
      * by the [evaluation][Evaluation]. We use [key] to identify unique actions and Formula
@@ -190,12 +195,11 @@ interface Action<Event> {
      * to clean up such as remove subscriptions to RxJava observables, Kotlin Flows, event buses,
      * etc.
      *
-     * @param send Use this listener to send events back to [Formula].
-     *             Note: you need to call this on the main thread.
+     * @param emitter Use emitter to send events back to [Formula].
      */
     fun start(
         scope: CoroutineScope,
-        send: (Event) -> Unit,
+        emitter: Emitter<Event>,
     ): Cancelable?
 
     /**

--- a/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
@@ -2,6 +2,7 @@ package com.instacart.formula
 
 import com.instacart.formula.internal.ListInspector
 import com.instacart.formula.plugin.Dispatcher
+import com.instacart.formula.plugin.FormulaError
 import com.instacart.formula.plugin.Inspector
 import com.instacart.formula.plugin.Plugin
 import kotlin.reflect.KClass
@@ -20,6 +21,10 @@ object FormulaPlugins {
             local == null -> global
             else -> ListInspector(listOf(global, local))
         }
+    }
+
+    fun onError(error: FormulaError) {
+        plugin?.onError(error)
     }
 
     fun onDuplicateChildKey(

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -373,7 +373,7 @@ class FormulaRuntime<Input : Any, Output : Any>(
             delegate = this,
             formula = implementation,
             initialInput = initialInput,
-            loggingType = formula::class,
+            formulaType = formula.type(),
             inspector = inspector,
             defaultDispatcher = defaultDispatcher,
         )

--- a/formula/src/main/java/com/instacart/formula/action/FlowAction.kt
+++ b/formula/src/main/java/com/instacart/formula/action/FlowAction.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.action
 
 import com.instacart.formula.Action
 import com.instacart.formula.Cancelable
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
@@ -22,11 +23,17 @@ internal class FlowAction<Event>(
 
     override fun key(): Any? = key
 
-    override fun start(scope: CoroutineScope, send: (Event) -> Unit): Cancelable {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Event>): Cancelable {
         val job = scope.launch(start = CoroutineStart.UNDISPATCHED) {
-            withContext(context) {
-                factory().collect {
-                    send(it)
+            try {
+                withContext(context) {
+                    factory().collect {
+                        emitter.onEvent(it)
+                    }
+                }
+            } catch (e: Exception) {
+                if (e !is CancellationException) {
+                    emitter.onError(e)
                 }
             }
         }

--- a/formula/src/main/java/com/instacart/formula/action/LaunchCoroutineAction.kt
+++ b/formula/src/main/java/com/instacart/formula/action/LaunchCoroutineAction.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.action
 
 import com.instacart.formula.Action
 import com.instacart.formula.Cancelable
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
@@ -20,14 +21,17 @@ internal class LaunchCoroutineAction<Result>(
 
     override fun key(): Any? = key
 
-    override fun start(
-        scope: CoroutineScope,
-        send: (Result) -> Unit,
-    ): Cancelable {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Result>): Cancelable {
         val job = scope.launch(start = CoroutineStart.UNDISPATCHED) {
             withContext(context) {
-                val result = block()
-                send(result)
+                try {
+                    val result = block()
+                    emitter.onEvent(result)
+                } catch (e: Exception) {
+                    if (e !is CancellationException) {
+                        emitter.onError(e)
+                    }
+                }
             }
         }
         return Cancelable(job::cancel)

--- a/formula/src/main/java/com/instacart/formula/action/StartEventAction.kt
+++ b/formula/src/main/java/com/instacart/formula/action/StartEventAction.kt
@@ -11,8 +11,8 @@ internal class StartEventAction<Data>(
     private val data: Data
 ) : Action<Data> {
 
-    override fun start(scope: CoroutineScope, send: (Data) -> Unit): Cancelable? {
-        send(data)
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Data>): Cancelable? {
+        emitter.onEvent(data)
         return null
     }
 

--- a/formula/src/main/java/com/instacart/formula/action/TerminateEventAction.kt
+++ b/formula/src/main/java/com/instacart/formula/action/TerminateEventAction.kt
@@ -8,9 +8,9 @@ import kotlinx.coroutines.CoroutineScope
  * Emits an event when [Formula] is terminated.
  */
 internal object TerminateEventAction : Action<Unit> {
-    override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Unit>): Cancelable? {
         return Cancelable {
-            send(Unit)
+            emitter.onEvent(Unit)
         }
     }
 

--- a/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
@@ -4,14 +4,12 @@ import com.instacart.formula.DeferredAction
 import com.instacart.formula.Evaluation
 import com.instacart.formula.plugin.Inspector
 import kotlinx.coroutines.isActive
-import kotlin.reflect.KClass
 
 /**
  * Handles [DeferredAction] changes.
  */
 internal class ActionManager(
     private val manager: FormulaManagerImpl<*, *, *>,
-    private val loggingType: KClass<*>,
     private val inspector: Inspector?,
 ) {
     /**
@@ -89,10 +87,10 @@ internal class ActionManager(
 
             val runningActions = getOrInitRunningActions()
             if (!runningActions.contains(action)) {
-                inspector?.onActionStarted(loggingType, action)
+                inspector?.onActionStarted(manager.formulaType, action)
 
                 runningActions.add(action)
-                action.start(manager.scope)
+                action.start(manager.scope, manager.formulaType.java)
 
                 if (manager.isTerminated()) {
                     return false
@@ -150,7 +148,7 @@ internal class ActionManager(
     }
 
     private fun finishAction(action: DeferredAction<*>) {
-        inspector?.onActionFinished(loggingType, action)
+        inspector?.onActionFinished(manager.formulaType, action)
         action.tearDown()
         action.listener = null
     }

--- a/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
@@ -69,7 +69,7 @@ internal class ChildrenManager(
              */
             if (logs.add(key)) {
                 FormulaPlugins.onDuplicateChildKey(
-                    parentFormulaType = delegate.loggingType.java,
+                    parentFormulaType = delegate.formulaType.java,
                     childFormulaType = formula.type().java,
                     key = key,
                 )
@@ -105,7 +105,7 @@ internal class ChildrenManager(
                 delegate = delegate,
                 formula = implementation,
                 initialInput = input,
-                loggingType = formula::class,
+                formulaType = formula.type(),
                 inspector = inspector,
                 defaultDispatcher = delegate.defaultDispatcher,
             )

--- a/formula/src/main/java/com/instacart/formula/plugin/FormulaError.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/FormulaError.kt
@@ -1,0 +1,9 @@
+package com.instacart.formula.plugin
+
+sealed class FormulaError {
+
+    data class ActionError(
+        val formula: Class<*>,
+        val error: Throwable,
+    ): FormulaError()
+}

--- a/formula/src/main/java/com/instacart/formula/plugin/Plugin.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/Plugin.kt
@@ -14,6 +14,11 @@ interface Plugin {
     }
 
     /**
+     * Notified when an error is thrown in a formula.
+     */
+    fun onError(error: FormulaError) = Unit
+
+    /**
      * Notified when there is a duplicate child key detected.
      */
     fun onDuplicateChildKey(

--- a/formula/src/test/java/com/instacart/formula/ActionTest.kt
+++ b/formula/src/test/java/com/instacart/formula/ActionTest.kt
@@ -177,6 +177,19 @@ class ActionTest {
     }
 
     @Test
+    fun `launch - cancellation does not emit an error`() = runTest {
+        val action = Action.launch {
+            delay(500)
+        }
+        val result = kotlin.runCatching {
+            action.test {
+                cancel()
+            }
+        }
+        assertThat(result.exceptionOrNull()).isNull()
+    }
+
+    @Test
     fun `fromFlow - default key is null`() {
         val action = Action.fromFlow { flowOf("") }
         assertThat(action.key()).isNull()
@@ -221,6 +234,20 @@ class ActionTest {
         assertThat(result.exceptionOrNull()).hasMessageThat().isEqualTo(
             "Expected no errors, but got: [java.lang.RuntimeException: Test exception]"
         )
+    }
+
+    @Test
+    fun `fromFlow - cancellation does not emit an error`() = runTest {
+        val action = Action.fromFlow<Unit> {
+            flow { delay(500) }
+        }
+
+        val result = kotlin.runCatching {
+            action.test {
+                cancel()
+            }
+        }
+        assertThat(result.exceptionOrNull()).isNull()
     }
 
     @OptIn(DelicateCoroutinesApi::class)

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -1506,9 +1506,12 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
                     actions = context.actions {
                         if (input) {
                             val action = object : Action<Unit> {
-                                override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable {
+                                override fun start(
+                                    scope: CoroutineScope,
+                                    emitter: Action.Emitter<Unit>
+                                ): Cancelable {
                                     return Cancelable {
-                                        send(Unit)
+                                        emitter.onEvent(Unit)
                                     }
                                 }
 
@@ -1548,7 +1551,10 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
 
                         if (input) {
                             val action = object : Action<Unit> {
-                                override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable {
+                                override fun start(
+                                    scope: CoroutineScope,
+                                    emitter: Action.Emitter<Unit>
+                                ): Cancelable {
                                     return Cancelable {
                                         newRelay.triggerEvent()
                                     }
@@ -1586,7 +1592,10 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
                     actions = context.actions {
                         if (input) {
                             val action = object : Action<Unit> {
-                                override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable {
+                                override fun start(
+                                    scope: CoroutineScope,
+                                    emitter: Action.Emitter<Unit>
+                                ): Cancelable {
                                     return Cancelable {
                                         terminate()
                                     }
@@ -1624,8 +1633,12 @@ class FormulaRuntimeTest(val runtime: TestableRuntime, val name: String) {
                         if (input) {
                             val action = object : Action<Unit> {
                                 override fun key(): Any? = null
-                                override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable? {
-                                    sendCallback = send
+
+                                override fun start(
+                                    scope: CoroutineScope,
+                                    emitter: Action.Emitter<Unit>
+                                ): Cancelable? {
+                                    sendCallback = emitter::onEvent
                                     return null
                                 }
                             }

--- a/formula/src/test/java/com/instacart/formula/FormulaValidationTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaValidationTest.kt
@@ -63,7 +63,7 @@ class FormulaValidationTest {
                         val action = object : Action<Unit> {
                             override fun start(
                                 scope: CoroutineScope,
-                                send: (Unit) -> Unit
+                                emitter: Action.Emitter<Unit>
                             ): Cancelable? {
                                 return null
                             }

--- a/formula/src/test/java/com/instacart/formula/actions/ErrorAction.kt
+++ b/formula/src/test/java/com/instacart/formula/actions/ErrorAction.kt
@@ -1,0 +1,16 @@
+package com.instacart.formula.actions
+
+import com.instacart.formula.Action
+import com.instacart.formula.Cancelable
+import kotlinx.coroutines.CoroutineScope
+
+class ErrorAction(
+    private val error: Throwable = RuntimeException("my error")
+) : Action<Unit> {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<Unit>): Cancelable? {
+        emitter.onError(error)
+        return null
+    }
+
+    override fun key(): Any? = null
+}

--- a/formula/src/test/java/com/instacart/formula/subjects/DynamicStreamSubject.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/DynamicStreamSubject.kt
@@ -47,7 +47,10 @@ class DynamicStreamSubject(runtime: TestableRuntime) {
 
         private fun action(key: String): Action<Unit> {
             return object : Action<Unit> {
-                override fun start(scope: CoroutineScope, send: (Unit) -> Unit): Cancelable? {
+                override fun start(
+                    scope: CoroutineScope,
+                    emitter: Action.Emitter<Unit>
+                ): Cancelable {
                     running.add(key)
                     return Cancelable {
                         running.remove(key)

--- a/samples/custom-network-state-stream/src/main/java/com/instacart/formula/samples/networkstate/NetworkStateStreamImpl.kt
+++ b/samples/custom-network-state-stream/src/main/java/com/instacart/formula/samples/networkstate/NetworkStateStreamImpl.kt
@@ -6,16 +6,17 @@ import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
 import android.net.ConnectivityManager
+import com.instacart.formula.Action
 import com.instacart.formula.Cancelable
 import kotlinx.coroutines.CoroutineScope
 
 class NetworkStateStreamImpl(private val application: Application) : NetworkStateStream {
-    override fun start(scope: CoroutineScope, send: (NetworkState) -> Unit): Cancelable? {
+    override fun start(scope: CoroutineScope, emitter: Action.Emitter<NetworkState>): Cancelable {
         // Broadcast receiver setup
         val action = IntentFilter(ConnectivityManager.CONNECTIVITY_ACTION)
         val receiver = object : BroadcastReceiver() {
             override fun onReceive(context: Context?, intent: Intent?) {
-                send(getNetworkState(application))
+                emitter.onEvent(getNetworkState(application))
             }
         }
 
@@ -23,7 +24,7 @@ class NetworkStateStreamImpl(private val application: Application) : NetworkStat
         application.registerReceiver(receiver, action, null, null);
 
         // Emit initial state
-        send(getNetworkState(application))
+        emitter.onEvent(getNetworkState(application))
 
         return Cancelable {
             // Unregister

--- a/samples/custom-network-state-stream/src/test/java/com/instacart/formula/stopwatch/NetworkStateFormulaTest.kt
+++ b/samples/custom-network-state-stream/src/test/java/com/instacart/formula/stopwatch/NetworkStateFormulaTest.kt
@@ -1,11 +1,13 @@
 package com.instacart.formula.stopwatch
 
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.Action
 import com.instacart.formula.Cancelable
 import com.instacart.formula.samples.networkstate.NetworkState
 import com.instacart.formula.samples.networkstate.NetworkStateFormula
 import com.instacart.formula.samples.networkstate.NetworkStateStream
 import com.instacart.formula.test.test
+import kotlinx.coroutines.CoroutineScope
 import org.junit.Test
 
 class NetworkStateFormulaTest {
@@ -31,11 +33,14 @@ class NetworkStateFormulaTest {
     private fun formula(isOnline: Boolean) = NetworkStateFormula(networkStateStream(isOnline))
 
     private fun networkStateStream(isOnline: Boolean) = object : NetworkStateStream {
-        override fun start(send: (NetworkState) -> Unit): Cancelable? {
+        override fun start(
+            scope: CoroutineScope,
+            emitter: Action.Emitter<NetworkState>
+        ): Cancelable? {
             // Adding extra events to ensure that it handles multiple updates
-            send(NetworkState(false))
-            send(NetworkState(true))
-            send(NetworkState(isOnline))
+            emitter.onEvent(NetworkState(false))
+            emitter.onEvent(NetworkState(true))
+            emitter.onEvent(NetworkState(isOnline))
             return null
         }
     }


### PR DESCRIPTION
## What
Currently, the unhandled action errors are handled quite inconsistently. To ensure consistent behavior
- Updating `Action` to have an `Emitter` which has `onError` function
- Added `FormulaPlugins.onError` that will be called when an error occurs