### PR TITLE
Ensure inspector.onRunFinished() is called.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -217,13 +217,15 @@ class FormulaRuntime<Input : Any, Output : Any>(
                 while (shouldRun) {
                     val localInputId = inputId
                     isRunning = true
-                    inspector?.onRunStarted(true)
 
-                    val currentInput = requireInput()
-                    runFormula(manager, currentInput)
-                    isRunning = false
-
-                    inspector?.onRunFinished()
+                    try {
+                        inspector?.onRunStarted(true)
+                        val currentInput = requireInput()
+                        runFormula(manager, currentInput)
+                    } finally {
+                        isRunning = false
+                        inspector?.onRunFinished()
+                    }
 
                     /**
                      * If termination happened during runFormula() execution, let's perform


### PR DESCRIPTION
Small change to ensure `inspector.onRunFinished` is called even if run formula errors out.