### PR TITLE
Remove ActivityStoreContext.selectActivityEvents.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
+++ b/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
@@ -10,7 +10,6 @@ import com.instacart.formula.android.events.ActivityResult
 import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.internal.ActivityStoreFactory
 import com.instacart.formula.android.internal.AppManager
-import com.instacart.formula.android.FragmentKey
 import java.lang.IllegalStateException
 
 object FormulaAndroid {

--- a/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/ActivityStoreContext.kt
@@ -54,15 +54,6 @@ abstract class ActivityStoreContext<out Activity : FragmentActivity> {
     abstract fun isFragmentResumed(key: FragmentKey): Observable<Boolean>
 
     /**
-     * This enables you to select specific events from the activity.
-     *
-     * @param Event Type of event
-     */
-    abstract fun <Event : Any> selectActivityEvents(
-        select: Activity.() -> Observable<Event>
-    ): Observable<Event>
-
-    /**
      * Performs an [effect] on the current activity instance. If there is no activity connected,
      * it will do nothing.
      */

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -16,7 +16,6 @@ import io.reactivex.rxjava3.core.Observable
  */
 internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityStoreContext<Activity>() {
 
-    private val attachEventRelay = BehaviorRelay.createDefault(false)
     private val startedRelay = PublishRelay.create<Unit>()
 
     private val fragmentLifecycleStates = mutableMapOf<String, Lifecycle.State>()
@@ -55,21 +54,6 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
         return isFragmentResumed(key.tag)
     }
 
-    override fun <Event : Any> selectActivityEvents(
-        select: Activity.() -> Observable<Event>
-    ): Observable<Event> {
-        // TODO: should probably use startedActivity
-        return attachEventRelay
-            .switchMap {
-                val activity = activity
-                if (activity == null) {
-                    Observable.empty<Event>()
-                } else {
-                    select(activity)
-                }
-            }
-    }
-
     override fun send(effect: Activity.() -> Unit) {
         // We allow emitting effects only after activity has started
         if (Utils.isMainThread()) {
@@ -94,7 +78,6 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
     fun attachActivity(activity: Activity) {
         hasStarted = false
         this.activity = activity
-        attachEventRelay.accept(true)
     }
 
     fun onActivityStarted(activity: Activity) {
@@ -105,7 +88,6 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
     fun detachActivity(activity: Activity) {
         if (this.activity == activity) {
             this.activity = null
-            attachEventRelay.accept(false)
         }
     }
 

--- a/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreContextTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreContextTest.kt
@@ -27,29 +27,6 @@ class ActivityStoreContextTest {
         context = ActivityStoreContextImpl()
     }
 
-    @Test fun `select activity events only runs when activity is attached`() {
-        val fakeEvents = context.selectActivityEvents { fakeEvents() }
-
-        fakeEvents
-            .test()
-            .apply {
-                fakeEventRelay.accept("missed")
-            }
-            .assertEmpty()
-            .apply {
-                val activity = createFakeActivity()
-                context.attachActivity(activity)
-
-                fakeEventRelay.accept("first")
-                fakeEventRelay.accept("second")
-
-                context.detachActivity(activity)
-
-                fakeEventRelay.accept("third")
-            }
-            .assertValues("first", "second")
-    }
-
     @Test fun `send drops events if activity is not started`() {
         val activity = createFakeActivity()
         context.attachActivity(activity)


### PR DESCRIPTION
## What

Removing `selectActivityEvents` since we are migrating slowly to coroutines and this API is not used.