### PR TITLE
[Coroutines] Cleaning up RxJava from runtime tests.

### DIFF
--- a/formula-rxjava3/src/test/java/com/instacart/formula/rxjava3/RxActionTest.kt
+++ b/formula-rxjava3/src/test/java/com/instacart/formula/rxjava3/RxActionTest.kt
@@ -1,0 +1,33 @@
+package com.instacart.formula.rxjava3
+
+import com.instacart.formula.test.test
+import com.jakewharton.rxrelay3.PublishRelay
+import io.reactivex.rxjava3.core.Observable
+import org.junit.Test
+
+class RxActionTest {
+
+    @Test fun `fromObservable emits multiple events`() {
+        val observer = RxAction
+            .fromObservable { Observable.just("a", "b") }
+            .test()
+
+        observer.assertValues("a", "b")
+        observer.cancel()
+    }
+
+    @Test fun `fromObservable cancellation stops emissions`() {
+        val relay = PublishRelay.create<String>()
+        val observer = RxAction
+            .fromObservable { relay }
+            .test()
+
+        observer.assertValues()
+        relay.accept("a")
+        observer.assertValues("a")
+
+        observer.cancel()
+        relay.accept("b")
+        observer.assertValues("a")
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/subjects/EventFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/EventFormula.kt
@@ -1,22 +1,29 @@
 package com.instacart.formula.subjects
 
+import com.instacart.formula.Action
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.Snapshot
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.test.TestableRuntime
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 
-class EventFormula<EventT : Any>(
-    runtime: TestableRuntime,
-    private val events: List<EventT>,
-) : Formula<Unit, Int, Int>() {
+class EventFormula<EventT : Any>(private val events: List<EventT>) : Formula<Unit, Int, Int>() {
 
     data class Event<EventT>(
         val state: Int,
         val event: EventT
     )
 
-    private val stream = runtime.emitEvents(events)
+    private val stream = Action.fromFlow {
+        flow {
+            for (event in events) {
+                emit(event)
+            }
+        }
+    }
+
     private val captured = TestEventCallback<Event<EventT>>()
 
     fun capturedStates() = captured.values().map { it.state }

--- a/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
@@ -1,21 +1,9 @@
 package com.instacart.formula.test
 
-import com.instacart.formula.Action
 import com.instacart.formula.IFormula
 import com.instacart.formula.RuntimeConfig
 import com.instacart.formula.plugin.Inspector
-import com.instacart.formula.toFlow
 import com.instacart.formula.plugin.Dispatcher
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.GlobalScope
-import kotlinx.coroutines.channels.BufferOverflow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 
 object CoroutinesTestableRuntime : TestableRuntime {
 
@@ -36,27 +24,5 @@ object CoroutinesTestableRuntime : TestableRuntime {
 
     override fun newRelay(): Relay {
         return FlowRelay()
-    }
-
-    override fun <T : Any> emitEvents(events: List<T>): Action<T> {
-        return Action.fromFlow {
-            flow {
-                events.forEach { emit(it) }
-            }
-        }
-    }
-}
-
-private class FlowRelay : Relay {
-    private val sharedFlow = MutableSharedFlow<Unit>(
-        replay = 0,
-        extraBufferCapacity = Int.MAX_VALUE,
-        onBufferOverflow = BufferOverflow.DROP_OLDEST,
-    )
-
-    override fun action(): Action<Unit> = Action.fromFlow { sharedFlow }
-
-    override fun triggerEvent() {
-        runBlocking { sharedFlow.emit(Unit) }
     }
 }

--- a/formula/src/test/java/com/instacart/formula/test/FlowRelay.kt
+++ b/formula/src/test/java/com/instacart/formula/test/FlowRelay.kt
@@ -1,0 +1,20 @@
+package com.instacart.formula.test
+
+import com.instacart.formula.Action
+import kotlinx.coroutines.channels.BufferOverflow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.runBlocking
+
+class FlowRelay : Relay {
+    private val sharedFlow = MutableSharedFlow<Unit>(
+        replay = 0,
+        extraBufferCapacity = Int.MAX_VALUE,
+        onBufferOverflow = BufferOverflow.DROP_OLDEST,
+    )
+
+    override fun action(): Action<Unit> = Action.fromFlow { sharedFlow }
+
+    override fun triggerEvent() {
+        runBlocking { sharedFlow.emit(Unit) }
+    }
+}

--- a/formula/src/test/java/com/instacart/formula/test/RxJavaTestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/RxJavaTestableRuntime.kt
@@ -29,12 +29,6 @@ object RxJavaTestableRuntime : TestableRuntime {
     override fun newRelay(): Relay {
         return RxRelay()
     }
-
-    override fun <T : Any> emitEvents(events: List<T>): Action<T> {
-        return RxAction.fromObservable {
-            Observable.fromIterable(events)
-        }
-    }
 }
 
 private class RxRelay : Relay {

--- a/formula/src/test/java/com/instacart/formula/test/TestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/TestableRuntime.kt
@@ -33,8 +33,6 @@ interface TestableRuntime {
     }
 
     fun newRelay(): Relay
-
-    fun <T : Any> emitEvents(events: List<T>): Action<T>
 }
 
 interface Relay {


### PR DESCRIPTION
# Description
Moving RxJava specific tests to `formula-rxjava3` module