### PR TITLE
[Coroutines] Cleaning up RxJava from runtime tests (pt2).

### DIFF
--- a/formula/src/test/java/com/instacart/formula/subjects/ChildStreamEvents.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/ChildStreamEvents.kt
@@ -6,7 +6,7 @@ import com.instacart.formula.test.TestableRuntime
 
 class ChildStreamEvents(runtime: TestableRuntime) {
 
-    private val child = StartStopFormula(runtime)
+    private val child = StartStopFormula()
     private val subject = runtime.test(HasChildFormula(child), Unit)
 
     fun startListening() = apply {

--- a/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StartStopFormula.kt
@@ -8,11 +8,11 @@ import com.instacart.formula.Transition
 import com.instacart.formula.TransitionContext
 import com.instacart.formula.subjects.StartStopFormula.Output
 import com.instacart.formula.subjects.StartStopFormula.State
-import com.instacart.formula.test.TestableRuntime
+import com.instacart.formula.test.FlowRelay
 
-class StartStopFormula(runtime: TestableRuntime) : Formula<Unit, State, Output>() {
+class StartStopFormula : Formula<Unit, State, Output>() {
 
-    val incrementEvents = runtime.newRelay()
+    val incrementEvents = FlowRelay()
 
     data class State(
         val listenForEvents: Boolean = false,

--- a/formula/src/test/java/com/instacart/formula/subjects/StateTransitionTimingFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/StateTransitionTimingFormula.kt
@@ -4,11 +4,10 @@ import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.Listener
 import com.instacart.formula.Snapshot
-import com.instacart.formula.test.TestableRuntime
+import com.instacart.formula.test.FlowRelay
 
-class StateTransitionTimingFormula(
-    runtime: TestableRuntime
-): Formula<Unit, List<StateTransitionTimingFormula.State>, StateTransitionTimingFormula.Output>() {
+class StateTransitionTimingFormula
+    : Formula<Unit, List<StateTransitionTimingFormula.State>, StateTransitionTimingFormula.Output>() {
 
     enum class State {
         INTERNAL,
@@ -20,7 +19,7 @@ class StateTransitionTimingFormula(
         val onStateTransition: Listener<Unit>,
     )
 
-    private val relay = runtime.newRelay()
+    private val relay = FlowRelay()
 
     override fun initialState(input: Unit): List<State> = emptyList()
 

--- a/formula/src/test/java/com/instacart/formula/subjects/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/SubscribesToAllUpdatesBeforeDeliveringMessages.kt
@@ -1,22 +1,25 @@
 package com.instacart.formula.subjects
 
+import com.instacart.formula.Action
 import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 import com.instacart.formula.Snapshot
 import com.instacart.formula.rxjava3.RxAction
+import com.instacart.formula.test.FlowRelay
 import com.instacart.formula.test.TestableRuntime
 import io.reactivex.rxjava3.core.Observable
+import kotlinx.coroutines.flow.flowOf
 
 object SubscribesToAllUpdatesBeforeDeliveringMessages {
 
-    fun test(runtime: TestableRuntime) = runtime.test(TestFormula(runtime), Unit)
+    fun test(runtime: TestableRuntime) = runtime.test(TestFormula(), Unit)
 
-    class TestFormula(runtime: TestableRuntime) : Formula<Unit, Int, Int>() {
-        private val initial = RxAction.fromObservable {
-            Observable.just(Unit, Unit, Unit, Unit)
+    class TestFormula : Formula<Unit, Int, Int>() {
+        private val initial = Action.fromFlow {
+            flowOf(Unit, Unit, Unit, Unit)
         }
         
-        private val incrementRelay = runtime.newRelay()
+        private val incrementRelay = FlowRelay()
 
         override fun initialState(input: Unit): Int = 0
 

--- a/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/CoroutineTestableRuntime.kt
@@ -21,8 +21,4 @@ object CoroutinesTestableRuntime : TestableRuntime {
         val delegate = CoroutineTestDelegate(formula, runtimeConfig)
         return TestFormulaObserver(delegate)
     }
-
-    override fun newRelay(): Relay {
-        return FlowRelay()
-    }
 }

--- a/formula/src/test/java/com/instacart/formula/test/RxJavaTestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/RxJavaTestableRuntime.kt
@@ -1,13 +1,9 @@
 package com.instacart.formula.test
 
-import com.instacart.formula.Action
 import com.instacart.formula.IFormula
 import com.instacart.formula.RuntimeConfig
 import com.instacart.formula.plugin.Dispatcher
 import com.instacart.formula.plugin.Inspector
-import com.instacart.formula.rxjava3.RxAction
-import com.jakewharton.rxrelay3.PublishRelay
-import io.reactivex.rxjava3.core.Observable
 
 object RxJavaTestableRuntime : TestableRuntime {
 
@@ -25,17 +21,4 @@ object RxJavaTestableRuntime : TestableRuntime {
         val delegate = RxJavaFormulaTestDelegate(formula, runtimeConfig)
         return TestFormulaObserver(delegate)
     }
-
-    override fun newRelay(): Relay {
-        return RxRelay()
-    }
 }
-
-private class RxRelay : Relay {
-    private val relay = PublishRelay.create<Unit>()
-
-    override fun action() = RxAction.fromObservable { relay }
-
-    override fun triggerEvent() = relay.accept(Unit)
-}
-

--- a/formula/src/test/java/com/instacart/formula/test/TestableRuntime.kt
+++ b/formula/src/test/java/com/instacart/formula/test/TestableRuntime.kt
@@ -31,8 +31,6 @@ interface TestableRuntime {
     ): TestFormulaObserver<Input, Output, F> {
         return test(formula, inspector, dispatcher).input(input)
     }
-
-    fun newRelay(): Relay
 }
 
 interface Relay {


### PR DESCRIPTION
## Description
Cleaning up RxJava from runtime tests
- Removing `RxRelay` and `newRelay` test runtime utility. 