### PR TITLE
Revert RxJava runtime.

### DIFF
--- a/formula-rxjava3/build.gradle.kts
+++ b/formula-rxjava3/build.gradle.kts
@@ -9,7 +9,6 @@ apply {
 
 dependencies {
     implementation(libs.kotlin)
-    implementation(libs.coroutines.rx3)
 
     api(project(":formula"))
     api(libs.rxjava)

--- a/formula/src/main/java/com/instacart/formula/RuntimeExtensions.kt
+++ b/formula/src/main/java/com/instacart/formula/RuntimeExtensions.kt
@@ -5,6 +5,7 @@ import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.buffer
 import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.flow.conflate
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
@@ -40,7 +41,7 @@ private fun <Input : Any, Output : Any> start(
 ): Flow<Output> {
     val callbackFlow = callbackFlow {
         val runtime = FormulaRuntime(
-            scope = this,
+            coroutineContext = coroutineContext,
             formula = formula,
             onOutput = this::trySend,
             onError = this::close,
@@ -56,6 +57,6 @@ private fun <Input : Any, Output : Any> start(
         }
     }
     return callbackFlow
-        .buffer(onBufferOverflow = BufferOverflow.DROP_OLDEST)
+        .conflate()
         .distinctUntilChanged()
 }

--- a/formula/src/test/java/com/instacart/formula/DirectRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/DirectRuntimeTest.kt
@@ -1,11 +1,9 @@
 package com.instacart.formula
 
-import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.internal.Try
 import com.instacart.formula.test.TestEventCallback
 import com.instacart.formula.types.InputIdentityFormula
-import kotlinx.coroutines.test.TestScope
 import org.junit.Test
 
 /**
@@ -21,7 +19,6 @@ class DirectRuntimeTest {
         val onOutput = TestEventCallback<Int>()
         val onError = TestEventCallback<Throwable>()
         val runtime = FormulaRuntime(
-            scope = TestScope(),
             formula = root,
             onOutput = onOutput,
             onError = onError,
@@ -40,7 +37,6 @@ class DirectRuntimeTest {
         val onOutput = TestEventCallback<Int>()
         val onError = TestEventCallback<Throwable>()
         val runtime = FormulaRuntime(
-            scope = TestScope(),
             formula = root,
             onOutput = onOutput,
             onError = onError,
@@ -60,7 +56,6 @@ class DirectRuntimeTest {
         val onOutput = TestEventCallback<Int>()
         val onError = TestEventCallback<Throwable>()
         val runtime = FormulaRuntime(
-            scope = TestScope(),
             formula = root,
             onOutput = onOutput,
             onError = onError,
@@ -80,7 +75,6 @@ class DirectRuntimeTest {
         val onOutput = TestEventCallback<Int>()
         val onError = TestEventCallback<Throwable>()
         val runtime = FormulaRuntime(
-            scope = TestScope(),
             formula = root,
             onOutput = onOutput,
             onError = onError,
@@ -96,7 +90,6 @@ class DirectRuntimeTest {
         val onOutput = TestEventCallback<Int>()
         val onError = TestEventCallback<Throwable>()
         val runtime = FormulaRuntime(
-            scope = TestScope(),
             formula = root,
             onOutput = onOutput,
             onError = onError,

--- a/formula/src/test/java/com/instacart/formula/rxjava3/RxJavaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/rxjava3/RxJavaRuntimeTest.kt
@@ -2,10 +2,15 @@ package com.instacart.formula.rxjava3
 
 import com.google.common.truth.Truth
 import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
 import com.instacart.formula.RuntimeConfig
+import com.instacart.formula.Snapshot
 import com.instacart.formula.test.CountingInspector
 import com.instacart.formula.types.InputIdentityFormula
 import io.reactivex.rxjava3.core.Observable
+import kotlinx.coroutines.flow.flowOf
 import org.junit.Test
 
 class RxJavaRuntimeTest {
@@ -33,5 +38,25 @@ class RxJavaRuntimeTest {
         val input = Observable.just(0, 1, 2)
         val observer = formula.toObservable(input).test()
         assertThat(observer.values().last()).isEqualTo(2)
+    }
+
+    @Test fun `incorporate flow action with rxjava runtime`() {
+        val formula = object : Formula<Unit, Int, Int>() {
+            override fun initialState(input: Unit): Int = 0
+
+            override fun Snapshot<Unit, Int>.evaluate(): Evaluation<Int> {
+                return Evaluation(
+                    output = state,
+                    actions = context.actions {
+                        Action.fromFlow { flowOf(1, 2) }.onEvent {
+                            transition(it)
+                        }
+                    }
+                )
+            }
+        }
+
+        val observer = formula.toObservable().test()
+        observer.assertValues(2)
     }
 }


### PR DESCRIPTION
## What
Reverting `RxJava` runtime since `toFlow` added unpredictable timing changes due to coroutines dispatching mechanisms. 