### PR TITLE
[Android] Move FragmentEnvironment into FragmentStore.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **Breaking**: Move factory functions from `FlowAction` to `Action`
 - **Breaking**: Move coroutines logic into `formula` and removed `formula-coroutines` module
 - **Breaking**: Remove `ActivityStore.streams`
+- **Breaking**: Moving `FragmentEnvironment` to `FragmentStore`
 
 ## [0.7.1] - June 28, 2022
 - **Breaking**: Rename `FragmentBindingBuilder` to `FragmentStoreBuilder`

--- a/formula-android-tests/src/test/java/com/instacart/formula/FormulaFragmentTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FormulaFragmentTest.kt
@@ -50,7 +50,7 @@ class FormulaFragmentTest {
                     errors.add(error)
                 }
             )
-            FormulaAndroid.init(app, environment) {
+            FormulaAndroid.init(app) {
                 activity<TestFormulaActivity> {
                     ActivityStore(
                         onRenderFragmentState = { a, state ->
@@ -58,7 +58,7 @@ class FormulaFragmentTest {
 
                             updateThreads.add(Thread.currentThread())
                         },
-                        fragmentStore = FragmentStore.init {
+                        fragmentStore = FragmentStore.Builder().setFragmentEnvironment(environment).build {
                             bind(
                                 featureFactory = TestFeatureFactory<TestKey>(
                                     render = { key, value ->

--- a/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
+++ b/formula-android-tests/src/test/java/com/instacart/formula/FragmentLifecycleStateTest.kt
@@ -24,7 +24,7 @@ class FragmentLifecycleStateTest {
             configure = {
                 activity<TestFormulaActivity> {
                     ActivityStore(
-                        fragmentStore = FragmentStore.init {
+                        fragmentStore = FragmentStore.Builder().build {
                             bind(NoOpFeatureFactory<TestKey>())
                             bind(NoOpFeatureFactory<TestKeyWithId>())
                         }

--- a/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
+++ b/formula-android/src/main/java/com/instacart/formula/FormulaAndroid.kt
@@ -7,7 +7,6 @@ import androidx.annotation.VisibleForTesting
 import androidx.fragment.app.FragmentActivity
 import com.instacart.formula.android.ActivityConfigurator
 import com.instacart.formula.android.events.ActivityResult
-import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.internal.ActivityStoreFactory
 import com.instacart.formula.android.internal.AppManager
 import java.lang.IllegalStateException
@@ -16,16 +15,12 @@ object FormulaAndroid {
 
     private var application: Application? = null
     private var appManager: AppManager? = null
-    private var fragmentEnvironment: FragmentEnvironment? = null
 
     /**
      * Initializes Formula Android integration. Should be called within [Application.onCreate].
-     *
-     * @param fragmentEnvironment Environment model that configures various event listeners.
      */
     fun init(
         application: Application,
-        fragmentEnvironment: FragmentEnvironment = FragmentEnvironment(),
         activities: ActivityConfigurator.() -> Unit
     ) {
         // Should we allow re-initialization?
@@ -33,13 +28,12 @@ object FormulaAndroid {
             throw IllegalStateException("can only initialize the store once.")
         }
 
-        val factory = ActivityStoreFactory(fragmentEnvironment, activities)
+        val factory = ActivityStoreFactory(activities)
         val appManager = AppManager(factory)
         application.registerActivityLifecycleCallbacks(appManager)
 
         this.application = application
         this.appManager = appManager
-        this.fragmentEnvironment = fragmentEnvironment
     }
 
     /**
@@ -90,10 +84,6 @@ object FormulaAndroid {
 
     internal fun appManagerOrThrow(): AppManager {
         return ensureInitialized(appManager)
-    }
-
-    internal fun fragmentEnvironment(): FragmentEnvironment {
-        return ensureInitialized(fragmentEnvironment)
     }
 
     private fun <T : Any> ensureInitialized(variable: T?): T {

--- a/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
@@ -5,7 +5,6 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
-import com.instacart.formula.FormulaAndroid
 import com.instacart.formula.android.internal.FormulaFragmentDelegate
 import com.instacart.formula.android.internal.getOrSetArguments
 import java.lang.Exception
@@ -31,8 +30,7 @@ class FormulaFragment : Fragment(), BaseFormulaFragment<Any> {
         getFormulaFragmentId()
     }
 
-    private val environment: FragmentEnvironment
-        get() = FormulaAndroid.fragmentEnvironment()
+    internal lateinit var environment: FragmentEnvironment
 
     private val fragmentDelegate: FragmentEnvironment.FragmentDelegate
         get() = environment.fragmentDelegate
@@ -44,7 +42,7 @@ class FormulaFragment : Fragment(), BaseFormulaFragment<Any> {
         get() = featureView?.lifecycleCallbacks
 
     override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View? {
-        val viewFactory = FormulaFragmentDelegate.viewFactory(this) ?: run {
+        val viewFactory = FormulaFragmentDelegate.viewFactory(environment, this) ?: run {
             // No view factory, no view
             return null
         }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityManager.kt
@@ -3,18 +3,15 @@ package com.instacart.formula.android.internal
 import androidx.fragment.app.FragmentActivity
 import androidx.lifecycle.Lifecycle
 import com.instacart.formula.android.events.ActivityResult
-import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.ActivityStore
 import com.instacart.formula.android.FormulaFragment
 import com.instacart.formula.android.ViewFactory
-import io.reactivex.rxjava3.disposables.CompositeDisposable
 import io.reactivex.rxjava3.disposables.Disposable
 
 /**
  * Activity manager connects [ActivityStore] and the [Activity].
  */
 internal class ActivityManager<Activity : FragmentActivity>(
-    private val environment: FragmentEnvironment,
     private val delegate: ActivityStoreContextImpl<Activity>,
     private val store: ActivityStore<Activity>
 ) {
@@ -34,7 +31,7 @@ internal class ActivityManager<Activity : FragmentActivity>(
         // Initialize render view
         fragmentRenderView = FragmentFlowRenderView(
             activity = activity,
-            fragmentEnvironment = environment,
+            store = store.fragmentStore,
             onLifecycleEvent = {
                 store.fragmentStore.onLifecycleEffect(it)
                 store.onFragmentLifecycleEvent?.invoke(it)
@@ -103,7 +100,7 @@ internal class ActivityManager<Activity : FragmentActivity>(
     private fun subscribeToFragmentStateChanges(): Disposable {
         return store
             .fragmentStore
-            .state(environment)
+            .state()
             .subscribe(delegate.fragmentStateRelay::accept)
     }
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreFactory.kt
@@ -7,15 +7,13 @@ import kotlin.reflect.KClass
 
 internal class ActivityStoreFactory internal constructor(
     private val bindings: Map<KClass<*>, ActivityConfigurator.Binding<*>>,
-    private val environment: FragmentEnvironment
 ) {
     companion object {
         operator fun invoke(
-            environment: FragmentEnvironment,
             activities: ActivityConfigurator.() -> Unit
         ): ActivityStoreFactory {
             val bindings = ActivityConfigurator().apply(activities).bindings
-            return ActivityStoreFactory(bindings, environment)
+            return ActivityStoreFactory(bindings)
         }
     }
 
@@ -26,7 +24,6 @@ internal class ActivityStoreFactory internal constructor(
         val activityDelegate = ActivityStoreContextImpl<A>()
         return initializer.init.invoke(activityDelegate).let { store ->
             ActivityManager(
-                environment = environment,
                 delegate = activityDelegate,
                 store = store
             )

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FormulaFragmentDelegate.kt
@@ -1,21 +1,24 @@
 package com.instacart.formula.android.internal
 
 import com.instacart.formula.FormulaAndroid
-import com.instacart.formula.FormulaAndroid.fragmentEnvironment
 import com.instacart.formula.android.FormulaFragment
+import com.instacart.formula.android.FragmentEnvironment
 import com.instacart.formula.android.ViewFactory
 
 internal object FormulaFragmentDelegate {
-    fun viewFactory(fragment: FormulaFragment): ViewFactory<Any>? {
+    fun viewFactory(
+        fragmentEnvironment: FragmentEnvironment,
+        fragment: FormulaFragment,
+    ): ViewFactory<Any>? {
         val appManager = FormulaAndroid.appManagerOrThrow()
         val activity = fragment.requireActivity()
         val viewFactory = appManager.findStore(activity)?.viewFactory(fragment) ?: run {
             // Log view factory is missing
             if (activity.isDestroyed) {
-                fragmentEnvironment().logger("Missing view factory because activity is destroyed: ${fragment.getFragmentKey()}")
+                fragmentEnvironment.logger("Missing view factory because activity is destroyed: ${fragment.getFragmentKey()}")
             } else {
                 val error = IllegalStateException("Formula with ${fragment.getFragmentKey()} is missing view factory.")
-                fragmentEnvironment().onScreenError(fragment.getFragmentKey(), error)
+                fragmentEnvironment.onScreenError(fragment.getFragmentKey(), error)
             }
 
             return null

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentStoreFormula.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentStoreFormula.kt
@@ -14,8 +14,9 @@ import com.jakewharton.rxrelay3.PublishRelay
 
 @PublishedApi
 internal class FragmentStoreFormula(
+    private val environment: FragmentEnvironment,
     private val featureComponent: FeatureComponent<*>,
-) : Formula<FragmentEnvironment, FragmentState, FragmentState>(){
+) : Formula<Unit, FragmentState, FragmentState>(){
     private val lifecycleEvents = PublishRelay.create<FragmentLifecycleEvent>()
     private val visibleContractEvents = PublishRelay.create<FragmentId>()
     private val hiddenContractEvents = PublishRelay.create<FragmentId>()
@@ -36,9 +37,9 @@ internal class FragmentStoreFormula(
         }
     }
 
-    override fun initialState(input: FragmentEnvironment): FragmentState = FragmentState()
+    override fun initialState(input: Unit): FragmentState = FragmentState()
 
-    override fun Snapshot<FragmentEnvironment, FragmentState>.evaluate(): Evaluation<FragmentState> {
+    override fun Snapshot<Unit, FragmentState>.evaluate(): Evaluation<FragmentState> {
         return Evaluation(
             output = state,
             actions = context.actions {
@@ -55,7 +56,7 @@ internal class FragmentStoreFormula(
                         }
                         is FragmentLifecycleEvent.Added -> {
                             if (!state.activeIds.contains(fragmentId)) {
-                                val feature = featureComponent.init(input, fragmentId)
+                                val feature = featureComponent.init(environment, fragmentId)
                                 val updated = state.copy(
                                     activeIds = state.activeIds.plus(fragmentId),
                                     features = state.features.plus(feature.id to feature)
@@ -86,7 +87,7 @@ internal class FragmentStoreFormula(
                     val feature = (entry.value as? FeatureEvent.Init)?.feature
                     if (feature != null) {
                         val action = FeatureObservableAction(
-                            fragmentEnvironment = input,
+                            fragmentEnvironment = environment,
                             fragmentId = fragmentId,
                             feature = feature,
                         )

--- a/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreFactoryTest.kt
@@ -15,7 +15,6 @@ class ActivityStoreFactoryTest {
 
     @Test fun `initialized store is live`() {
         val factory = ActivityStoreFactory(
-            environment = FragmentEnvironment(),
             activities = {
                 activity(FakeActivity::class) {
                     ActivityStore()
@@ -29,7 +28,6 @@ class ActivityStoreFactoryTest {
 
     @Test fun `returns null if no binding for activity is found`() {
         val factory = ActivityStoreFactory(
-            environment = FragmentEnvironment(),
             activities = {}
         )
 

--- a/formula-android/src/test/java/com/instacart/formula/android/ViewFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ViewFactoryTest.kt
@@ -20,7 +20,7 @@ class ViewFactoryTest {
             configure = {
                 activity<TestFormulaActivity> {
                     ActivityStore(
-                        fragmentStore = FragmentStore.init {
+                        fragmentStore = FragmentStore.Builder().build {
                             val featureFactory = NoOpFeatureFactory(
                                 viewFactory = ViewFactory.fromLayout(TestR.layout.test_fragment_layout) {
                                     featureView {  }

--- a/formula-android/src/test/java/com/instacart/formula/android/test/FeatureFactoryLifecycleInteractor.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/test/FeatureFactoryLifecycleInteractor.kt
@@ -24,7 +24,7 @@ fun runFeatureFactoryLifecycleTest(
         configure = {
             activity<TestFormulaActivity> {
                 ActivityStore(
-                    fragmentStore = FragmentStore.init {
+                    fragmentStore = FragmentStore.Builder().build {
                         val featureFactory = NoOpFeatureFactory<TestKey>(
                             viewFactory = TestViewFactory(lifecycleCallback)
                         )

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchApp.kt
@@ -12,19 +12,21 @@ class StopwatchApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        val fragmentEnvironment = FragmentEnvironment(
+            onScreenError = { _, error ->
+                Log.e("StopwatchApp", "fragment crashed", error)
+            }
+        )
         FormulaAndroid.init(
             application = this,
-            fragmentEnvironment = FragmentEnvironment(
-                onScreenError = { key, error ->
-                    Log.e("StopwatchApp", "fragment crashed", error)
-                }
-            ),
             activities = {
                 activity<StopwatchActivity> {
                     ActivityStore(
-                        fragmentStore = FragmentStore.init(Unit) {
-                            bind(StopwatchFeatureFactory())
-                        }
+                        fragmentStore = FragmentStore.Builder()
+                            .setFragmentEnvironment(fragmentEnvironment)
+                            .build {
+                                bind(StopwatchFeatureFactory())
+                            }
                     )
                 }
             }

--- a/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/TodoApp.kt
@@ -13,21 +13,24 @@ class TodoApp : Application() {
     override fun onCreate() {
         super.onCreate()
 
+        val fragmentEnvironment = FragmentEnvironment(
+            onScreenError = { _, error ->
+                Log.e("TodoApp", "fragment crashed", error)
+            }
+        )
+
         FormulaAndroid.init(
             application = this,
-            fragmentEnvironment = FragmentEnvironment(
-                onScreenError = { _, error ->
-                    Log.e("TodoApp", "fragment crashed", error)
-                }
-            ),
             activities = {
                 activity<TodoActivity> {
                     val component = TodoAppComponent(this)
 
                     ActivityStore(
-                        fragmentStore = FragmentStore.init(component) {
-                            bind(TaskListFeatureFactory())
-                        }
+                        fragmentStore = FragmentStore.Builder()
+                            .setFragmentEnvironment(fragmentEnvironment)
+                            .build(component) {
+                                bind(TaskListFeatureFactory())
+                            }
                     )
                 }
             }

--- a/test-utils/android/src/main/java/com/instacart/testutils/android/TestExtensions.kt
+++ b/test-utils/android/src/main/java/com/instacart/testutils/android/TestExtensions.kt
@@ -7,7 +7,6 @@ import androidx.test.core.app.ActivityScenario
 import androidx.test.core.app.ApplicationProvider
 import com.google.common.truth.Truth.assertThat
 import com.instacart.formula.FormulaAndroid
-import com.instacart.formula.android.FragmentEnvironment
 import io.reactivex.rxjava3.plugins.RxJavaPlugins
 import org.robolectric.Shadows
 import java.util.concurrent.CountDownLatch
@@ -43,7 +42,6 @@ fun executeOnBackgroundThread(action: () -> Unit) {
 }
 
 fun withFormulaAndroid(
-    environment: FragmentEnvironment = FragmentEnvironment(),
     configure: TestActivityConfigurator.() -> Unit = {},
     continuation: (FormulaAndroidInteractor) -> Unit,
 ) {
@@ -54,7 +52,7 @@ fun withFormulaAndroid(
     try {
         val context = ApplicationProvider.getApplicationContext<Application>()
         val interactor = FormulaAndroidInteractor()
-        FormulaAndroid.init(context, environment) {
+        FormulaAndroid.init(context) {
             val testActivityConfigurator = TestActivityConfigurator(this) {
                 interactor.onActivityContextInitialized(it)
             }


### PR DESCRIPTION
## What
Moving `FragmentEnvironment` to `FragmentStore`. It doesn't make sense to pass `FragmentEnvironment` if there is no `FragmentStore`