### PR TITLE
[Android] Remove BehaviorRelay from ComposeViewFactory.

### DIFF
--- a/formula-android-compose/src/main/java/com/instacart/formula/android/compose/ComposeViewFactory.kt
+++ b/formula-android-compose/src/main/java/com/instacart/formula/android/compose/ComposeViewFactory.kt
@@ -1,12 +1,11 @@
 package com.instacart.formula.android.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rxjava3.subscribeAsState
+import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
 import com.instacart.formula.android.FeatureView
 import com.instacart.formula.android.ViewFactory
-import com.jakewharton.rxrelay3.BehaviorRelay
 
 abstract class ComposeViewFactory<RenderModel : Any> : ViewFactory<RenderModel> {
 
@@ -15,17 +14,17 @@ abstract class ComposeViewFactory<RenderModel : Any> : ViewFactory<RenderModel> 
         // Based-on: https://developer.android.com/develop/ui/compose/migrate/interoperability-apis/compose-in-views#compose-in-fragments
         view.setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
 
-        val outputRelay = BehaviorRelay.create<RenderModel>()
-        val initialModel = initialModel()
+        val outputState = mutableStateOf(initialModel())
         view.setContent {
-            val model = outputRelay.subscribeAsState(initialModel).value
-            if (model != null) {
+            outputState.value?.let { model ->
                 Content(model)
             }
         }
         return FeatureView(
             view = view,
-            setOutput = outputRelay::accept,
+            setOutput = { newValue ->
+                outputState.value = newValue
+            },
             lifecycleCallbacks = null,
         )
     }


### PR DESCRIPTION
## What
As part of the project to remove RxJava from formula core, I'm migrating `ComposeViewFactory` to use `mutableStateOf` instead.