### PR TITLE
[Android] Move instance id into FragmentKey.

### DIFF
--- a/docs/Formula-Android.md
+++ b/docs/Formula-Android.md
@@ -28,7 +28,7 @@ use. You can also use it to add arguments that the fragment instance needs.
 @Parcelize
 data class CounterKey(
     override val tag: String = "counter"
-) : FragmentKey
+) : FragmentKey()
 ```
 
 ### Define a feature factory
@@ -119,7 +119,7 @@ value to the `CounterFormula` used in the previous examples. To accomplish that,
 data class CounterKey(
     val initialCount: Int = 0,    
     override val tag: String = "counter"
-) : FragmentKey
+) : FragmentKey()
 ```
 
 You can access the `CounterKey` within `CounterFeatureFactory`

--- a/formula-android-tests/src/main/java/com/instacart/formula/test/TestKeyWithId.kt
+++ b/formula-android-tests/src/main/java/com/instacart/formula/test/TestKeyWithId.kt
@@ -7,4 +7,4 @@ import kotlinx.parcelize.Parcelize
 data class TestKeyWithId(
     val id: Int,
     override val tag: String = "test-key-$id",
-) : FragmentKey
+) : FragmentKey()

--- a/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
@@ -5,6 +5,7 @@ import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
 import androidx.fragment.app.Fragment
+import com.instacart.formula.android.internal.getFragmentInstanceId
 import com.instacart.formula.android.internal.getOrSetArguments
 import java.lang.Exception
 
@@ -17,16 +18,19 @@ class FormulaFragment : Fragment(), BaseFormulaFragment<Any> {
         fun newInstance(key: FragmentKey): FormulaFragment {
             return FormulaFragment().apply {
                 getOrSetArguments().putParcelable(ARG_CONTRACT, key)
+                getOrSetArguments().putString(ARG_FORMULA_ID, key.getOrInitInstanceId())
             }
         }
     }
 
-    private val key: FragmentKey by lazy(LazyThreadSafetyMode.NONE) {
-        requireArguments().getParcelable<FragmentKey>(ARG_CONTRACT)!!
-    }
-
     private val formulaFragmentId: FragmentId by lazy {
         getFormulaFragmentId()
+    }
+
+    private val key: FragmentKey by lazy(LazyThreadSafetyMode.NONE) {
+        val fragmentKey = requireNotNull(requireArguments().getParcelable<FragmentKey>(ARG_CONTRACT))
+        fragmentKey.setInstanceId(getFragmentInstanceId())
+        fragmentKey
     }
 
     internal lateinit var fragmentStore: FragmentStore

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentId.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentId.kt
@@ -1,8 +1,8 @@
 package com.instacart.formula.android
 
 import androidx.fragment.app.Fragment
+import com.instacart.formula.android.internal.EmptyFragmentKey
 import com.instacart.formula.android.internal.getFragmentInstanceId
-import com.instacart.formula.android.internal.getFragmentKey
 
 /**
  * An object used to identify a fragment. It combines both a user generated [key] and
@@ -22,8 +22,18 @@ data class FragmentId(
  * Gets a [FragmentId] for a given [Fragment].
  */
 fun Fragment.getFormulaFragmentId(): FragmentId {
+    val key = getFragmentKey()
     return FragmentId(
-        instanceId = getFragmentInstanceId(),
-        key = getFragmentKey()
+        instanceId = key.getOrInitInstanceId(),
+        key = key
     )
+}
+
+internal fun Fragment.getFragmentKey(): FragmentKey {
+    val fragment = this as? BaseFormulaFragment<*>
+    val key = fragment?.getFragmentKey() ?: EmptyFragmentKey(tag.orEmpty())
+    if (key.getInstanceId() == null) {
+        key.setInstanceId(getFragmentInstanceId())
+    }
+    return key
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentKey.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentKey.kt
@@ -2,6 +2,7 @@ package com.instacart.formula.android
 
 import android.os.Parcelable
 import androidx.fragment.app.FragmentManager
+import java.util.UUID
 
 /**
  * A key is used to identify a specific [FormulaFragment] and to connect the correct [FeatureFactory].
@@ -9,15 +10,37 @@ import androidx.fragment.app.FragmentManager
  * ```
  * data class TaskDetailKey(
  *   val taskID: String
- * ) : FragmentKey {
+ * ) : FragmentKey() {
  *   override val tag: String = "task-detail-$taskId"
  * }
  * ```
  */
-interface FragmentKey : Parcelable {
+abstract class FragmentKey : Parcelable {
 
     /**
      * Tag is a unique identifier used to distinguish each fragment instance by the [FragmentManager].
      */
-    val tag: String
+    abstract val tag: String
+
+    /**
+     * A unique identifier used to distinguish a fragment. Since there can be multiple
+     * fragments with same parameters, we use this as an extra identifier.
+     */
+    private var instanceId: String? = null
+
+    fun setInstanceId(value: String) {
+        instanceId = value
+    }
+
+    fun getOrInitInstanceId(): String {
+        return instanceId ?: run {
+            UUID.randomUUID().toString().apply {
+                instanceId = this
+            }
+        }
+    }
+
+    fun getInstanceId(): String? {
+        return instanceId
+    }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/EmptyFragmentKey.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/EmptyFragmentKey.kt
@@ -6,4 +6,4 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 internal data class EmptyFragmentKey(
     override val tag: String
-) : FragmentKey
+) : FragmentKey()

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentLifecycle.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentLifecycle.kt
@@ -3,9 +3,6 @@ package com.instacart.formula.android.internal
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentInspector
-import com.instacart.formula.android.FragmentId
-import com.instacart.formula.android.FragmentKey
-import com.instacart.formula.android.BaseFormulaFragment
 import com.instacart.formula.android.FormulaFragment
 import java.util.UUID
 
@@ -17,11 +14,6 @@ internal object FragmentLifecycle {
     internal fun shouldTrack(fragment: Fragment): Boolean {
         return !fragment.retainInstance && !FragmentInspector.isHeadless(fragment)
     }
-}
-
-internal fun Fragment.getFragmentKey(): FragmentKey {
-    val fragment = this as? BaseFormulaFragment<*>
-    return fragment?.getFragmentKey() ?: EmptyFragmentKey(tag.orEmpty())
 }
 
 /**

--- a/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreContextTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/ActivityStoreContextTest.kt
@@ -85,5 +85,5 @@ class ActivityStoreContextTest {
     @Parcelize
     private data class TestFragmentKey(
         override val tag: String = "fake tag",
-    ): FragmentKey
+    ): FragmentKey()
 }

--- a/formula-android/src/test/java/com/instacart/formula/android/FragmentKeyTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/FragmentKeyTest.kt
@@ -1,0 +1,44 @@
+package com.instacart.formula.android
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.google.common.truth.Truth.assertThat
+import com.instacart.formula.android.internal.EmptyFragmentKey
+import com.instacart.formula.android.test.ParcelableTestUtils
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class FragmentKeyTest {
+
+    @Test fun `parcelize does not save instance id`() {
+        val key = EmptyFragmentKey("my-tag")
+        key.setInstanceId("my-instance-id")
+
+        val savedKey = ParcelableTestUtils.recreate(key)
+        assertThat(savedKey.getInstanceId()).isNull()
+    }
+
+    @Test fun `getOrInitInstanceId always returns the same value`() {
+
+        val key = EmptyFragmentKey("tag-1")
+        val value = key.getOrInitInstanceId()
+        assertThat(value).isNotNull()
+        assertThat(key.getOrInitInstanceId()).isEqualTo(value)
+        assertThat(key.getOrInitInstanceId()).isEqualTo(value)
+    }
+
+    @Test fun `getOrInitInstanceId generates a random value if no value exists`() {
+        val key = EmptyFragmentKey("tag-1")
+        assertThat(key.getOrInitInstanceId()).isNotNull()
+
+        val key2 = EmptyFragmentKey("tag-2")
+        assertThat(key2.getOrInitInstanceId()).isNotEqualTo(key.getOrInitInstanceId())
+    }
+
+    @Test fun `getOrInitInstance uses existing value if already set`() {
+        val key = EmptyFragmentKey("my-tag")
+        key.setInstanceId("my-instance-id")
+
+        assertThat(key.getOrInitInstanceId()).isEqualTo("my-instance-id")
+    }
+}

--- a/formula-android/src/test/java/com/instacart/formula/android/fakes/DetailKey.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/fakes/DetailKey.kt
@@ -7,4 +7,4 @@ import kotlinx.parcelize.Parcelize
 data class DetailKey(
     val id: Int,
     override val tag: String = "detail-$id",
-) : FragmentKey
+) : FragmentKey()

--- a/formula-android/src/test/java/com/instacart/formula/android/fakes/MainKey.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/fakes/MainKey.kt
@@ -7,4 +7,4 @@ import kotlinx.parcelize.Parcelize
 data class MainKey(
     val id: Int,
     override val tag: String = "main-$id",
-) : FragmentKey
+) : FragmentKey()

--- a/formula-android/src/test/java/com/instacart/formula/android/test/ParcelableTestUtils.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/test/ParcelableTestUtils.kt
@@ -1,0 +1,40 @@
+package com.instacart.formula.android.test
+
+import android.os.Bundle
+import android.os.Parcel
+import android.os.Parcelable
+import org.junit.Assert.assertEquals
+
+object ParcelableTestUtils {
+
+    inline fun <reified T : Parcelable> recreateAndCompare(original: T): T {
+        val copy = recreate(original)
+        assertEquals(original, copy)
+        return copy
+    }
+
+    inline fun <reified T : Parcelable> recreate(original: T): T {
+        val bundle = Bundle().apply { putParcelable(T::class.java.name, original) }
+        val bytes = Parcel.obtain().run {
+            writeBundle(bundle)
+            val array = marshall()
+            recycle()
+            array
+        }
+
+        return unmarshallParcelable(bytes)
+    }
+
+    inline fun <reified T : Parcelable> unmarshallParcelable(bytes: ByteArray): T {
+        val parcel = Parcel.obtain().apply {
+            unmarshall(bytes, 0, bytes.size)
+            setDataPosition(0)
+        }
+
+        val value: T = parcel
+            .readBundle(T::class.java.classLoader)!!
+            .getParcelable(T::class.java.name)!!
+        parcel.recycle()
+        return value
+    }
+}

--- a/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchKey.kt
+++ b/samples/stopwatch-compose/src/main/java/com/instacart/formula/compose/stopwatch/StopwatchKey.kt
@@ -4,4 +4,4 @@ import com.instacart.formula.android.FragmentKey
 import kotlinx.parcelize.Parcelize
 
 @Parcelize
-data class StopwatchKey(override val tag: String = "stopwatch"): FragmentKey
+data class StopwatchKey(override val tag: String = "stopwatch"): FragmentKey()

--- a/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListKey.kt
+++ b/samples/todoapp/src/main/java/com/examples/todoapp/tasks/TaskListKey.kt
@@ -6,4 +6,4 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class TaskListKey(
     override val tag: String = "task list",
-) : FragmentKey
+) : FragmentKey()

--- a/test-utils/android/src/main/java/com/instacart/testutils/android/StateFlowKey.kt
+++ b/test-utils/android/src/main/java/com/instacart/testutils/android/StateFlowKey.kt
@@ -7,4 +7,4 @@ import kotlinx.parcelize.Parcelize
 data class StateFlowKey(
     val initAsync: Boolean,
     override val tag: String = "state flow key",
-) : FragmentKey
+) : FragmentKey()

--- a/test-utils/android/src/main/java/com/instacart/testutils/android/TestKey.kt
+++ b/test-utils/android/src/main/java/com/instacart/testutils/android/TestKey.kt
@@ -6,4 +6,4 @@ import kotlinx.parcelize.Parcelize
 @Parcelize
 data class TestKey(
     override val tag: String = "test key",
-) : FragmentKey
+) : FragmentKey()


### PR DESCRIPTION
## Description
Making `FragmentKey` into an abstract class and passing `instanceId` as part of it. Having a separate `FragmentId` composite type is making downstream APIs more complicated. The goal is to remove `FragmentId` from the `FeatureFactory` API.

One side-effect of using `instanceId` on the `FragmentKey` is that we cannot reuse the same instance for multiple fragments. 

- TODO: the problem is that `data object MyKey : FragmentKey()` is not allowed. 




