### PR TITLE
[Android] Add key type to FragmentId.

### DIFF
--- a/formula-android/src/main/java/com/instacart/formula/android/FeatureEvent.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FeatureEvent.kt
@@ -1,9 +1,9 @@
 package com.instacart.formula.android
 
 sealed class FeatureEvent {
-    data class Init(override val id: FragmentId, val feature: Feature): FeatureEvent()
-    data class Failure(override val id: FragmentId, val error: Throwable): FeatureEvent()
-    data class MissingBinding(override val id: FragmentId): FeatureEvent()
+    data class Init(override val id: FragmentId<*>, val feature: Feature): FeatureEvent()
+    data class Failure(override val id: FragmentId<*>, val error: Throwable): FeatureEvent()
+    data class MissingBinding(override val id: FragmentId<*>): FeatureEvent()
 
-    abstract val id: FragmentId
+    abstract val id: FragmentId<*>
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FeatureFactory.kt
@@ -39,9 +39,10 @@ abstract class FeatureFactory<in Dependencies, in Key : FragmentKey> {
 
     inner class Params(
         val dependencies: @UnsafeVariance Dependencies,
-        val fragmentId: FragmentId,
-        val key: @UnsafeVariance Key,
-    )
+        val fragmentId: FragmentId<@UnsafeVariance Key>,
+    ) {
+        val key = fragmentId.key
+    }
 
     /**
      * Initializes the [Feature] using [Params] provided.
@@ -51,7 +52,7 @@ abstract class FeatureFactory<in Dependencies, in Key : FragmentKey> {
     /**
      * Initializes state observable and a view factory for a specific [key].
      */
-    fun initialize(dependencies: Dependencies, fragmentId: FragmentId, key: Key): Feature {
-        return Params(dependencies, fragmentId, key).initialize()
+    fun initialize(dependencies: Dependencies, fragmentId: FragmentId<@UnsafeVariance Key>): Feature {
+        return Params(dependencies, fragmentId).initialize()
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FormulaFragment.kt
@@ -25,7 +25,7 @@ class FormulaFragment : Fragment(), BaseFormulaFragment<Any> {
         requireArguments().getParcelable<FragmentKey>(ARG_CONTRACT)!!
     }
 
-    private val formulaFragmentId: FragmentId by lazy {
+    private val formulaFragmentId: FragmentId<*> by lazy {
         getFormulaFragmentId()
     }
 

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentEnvironment.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentEnvironment.kt
@@ -15,19 +15,18 @@ data class FragmentEnvironment(
          * Instantiates the feature.
          */
         open fun <DependenciesT, KeyT: FragmentKey> initializeFeature(
-            fragmentId: FragmentId,
+            fragmentId: FragmentId<KeyT>,
             factory: FeatureFactory<DependenciesT, KeyT>,
             dependencies: DependenciesT,
-            key: KeyT,
         ): Feature {
-            return factory.initialize(dependencies, fragmentId, key)
+            return factory.initialize(dependencies, fragmentId)
         }
 
         /**
          * Called from [FormulaFragment.onCreateView] to instantiate the view.
          */
         open fun createView(
-            fragmentId: FragmentId,
+            fragmentId: FragmentId<*>,
             viewFactory: ViewFactory<Any>,
             params: ViewFactory.Params,
         ): FeatureView<Any> {
@@ -37,7 +36,7 @@ data class FragmentEnvironment(
         /**
          * Called when we are ready to apply [output] to the view.
          */
-        open fun setOutput(fragmentId: FragmentId, output: Any, applyOutputToView: (Any) -> Unit) {
+        open fun setOutput(fragmentId: FragmentId<*>, output: Any, applyOutputToView: (Any) -> Unit) {
             applyOutputToView(output)
         }
     }

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentId.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentId.kt
@@ -13,15 +13,15 @@ import com.instacart.formula.android.internal.getFragmentKey
  *
  * @param key Fragment key used to create this fragment.
  */
-data class FragmentId(
+data class FragmentId<out Type : FragmentKey>(
     val instanceId: String,
-    val key: FragmentKey
+    val key: Type,
 )
 
 /**
  * Gets a [FragmentId] for a given [Fragment].
  */
-fun Fragment.getFormulaFragmentId(): FragmentId {
+fun Fragment.getFormulaFragmentId(): FragmentId<*> {
     return FragmentId(
         instanceId = getFragmentInstanceId(),
         key = getFragmentKey()

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentState.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentState.kt
@@ -8,10 +8,10 @@ package com.instacart.formula.android
  * @param outputs Last emitted output of each active [FragmentKey].
  */
 data class FragmentState(
-    val activeIds: List<FragmentId> = emptyList(),
-    val visibleIds: List<FragmentId> = emptyList(),
-    val outputs: Map<FragmentId, FragmentOutput> = emptyMap(),
-    internal val features: Map<FragmentId, FeatureEvent> = emptyMap(),
+    val activeIds: List<FragmentId<*>> = emptyList(),
+    val visibleIds: List<FragmentId<*>> = emptyList(),
+    val outputs: Map<FragmentId<*>, FragmentOutput> = emptyMap(),
+    internal val features: Map<FragmentId<*>, FeatureEvent> = emptyMap(),
 ) {
     fun visibleOutput() = visibleIds.lastOrNull()?.let { outputs[it] }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/FragmentStore.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/FragmentStore.kt
@@ -81,7 +81,7 @@ class FragmentStore @PublishedApi internal constructor(
         val EMPTY = Builder().build {  }
     }
 
-    private val features = mutableMapOf<FragmentId, FeatureEvent>()
+    private val features = mutableMapOf<FragmentId<*>, FeatureEvent>()
 
     internal fun onLifecycleEvent(event: FragmentLifecycleEvent) {
         val fragmentId = event.fragmentId
@@ -103,7 +103,7 @@ class FragmentStore @PublishedApi internal constructor(
         onFragmentLifecycleEvent?.invoke(event)
     }
 
-    internal fun onVisibilityChanged(fragmentId: FragmentId, visible: Boolean) {
+    internal fun onVisibilityChanged(fragmentId: FragmentId<*>, visible: Boolean) {
         if (visible) {
             formula.fragmentVisible(fragmentId)
         } else {
@@ -118,7 +118,7 @@ class FragmentStore @PublishedApi internal constructor(
         return formula.toObservable(config)
     }
 
-    internal fun getViewFactory(fragmentId: FragmentId): ViewFactory<Any>? {
+    internal fun getViewFactory(fragmentId: FragmentId<*>): ViewFactory<Any>? {
         return features.getViewFactory(environment, fragmentId)
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/events/FragmentLifecycleEvent.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/events/FragmentLifecycleEvent.kt
@@ -8,14 +8,14 @@ import com.instacart.formula.android.FragmentId
  */
 sealed class FragmentLifecycleEvent {
 
-    abstract val fragmentId: FragmentId
+    abstract val fragmentId: FragmentId<*>
 
     data class Added(
-        override val fragmentId: FragmentId
+        override val fragmentId: FragmentId<*>
     ) : FragmentLifecycleEvent()
 
     data class Removed(
-        override val fragmentId: FragmentId,
+        override val fragmentId: FragmentId<*>,
         val lastState: Any? = null
     ) : FragmentLifecycleEvent()
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/ActivityStoreContextImpl.kt
@@ -84,7 +84,7 @@ internal class ActivityStoreContextImpl<Activity : FragmentActivity> : ActivityS
         }
     }
 
-    fun updateFragmentLifecycleState(id: FragmentId, newState: Lifecycle.State) {
+    fun updateFragmentLifecycleState(id: FragmentId<*>, newState: Lifecycle.State) {
         // TODO: should probably start using [id] instead of [contract] here.
         val contract = id.key
         if (newState == Lifecycle.State.DESTROYED) {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureComponent.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureComponent.kt
@@ -11,7 +11,7 @@ class FeatureComponent<in Component>(
     private val bindings: List<FeatureBinding<Component, *>>,
 ) {
 
-    fun init(environment: FragmentEnvironment, fragmentId: FragmentId): FeatureEvent {
+    fun init(environment: FragmentEnvironment, fragmentId: FragmentId<*>): FeatureEvent {
         val initialized = try {
             bindings.firstNotNullOfOrNull { binding ->
                 if (binding.type.isInstance(fragmentId.key)) {
@@ -20,7 +20,6 @@ class FeatureComponent<in Component>(
                         fragmentId = fragmentId,
                         factory = featureFactory,
                         dependencies = component,
-                        key = fragmentId.key,
                     )
                     FeatureEvent.Init(fragmentId, feature)
                 } else {

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FeatureObservableAction.kt
@@ -11,7 +11,7 @@ import kotlinx.coroutines.CoroutineScope
 
 class FeatureObservableAction internal constructor(
     private val fragmentEnvironment: FragmentEnvironment,
-    private val fragmentId: FragmentId,
+    private val fragmentId: FragmentId<*>,
     private val feature: RxJavaFeature,
 ) : Action<Any> {
 

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentFlowRenderView.kt
@@ -28,8 +28,8 @@ import java.util.LinkedList
 internal class FragmentFlowRenderView(
     private val activity: FragmentActivity,
     private val store: FragmentStore,
-    private val onLifecycleState: (FragmentId, Lifecycle.State) -> Unit,
-    private val onFragmentViewStateChanged: (FragmentId, isVisible: Boolean) -> Unit
+    private val onLifecycleState: (FragmentId<*>, Lifecycle.State) -> Unit,
+    private val onFragmentViewStateChanged: (FragmentId<*>, isVisible: Boolean) -> Unit
 ) {
     private var fragmentState: FragmentState? = null
     private val visibleFragments: LinkedList<Fragment> = LinkedList()

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentStoreFormula.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/FragmentStoreFormula.kt
@@ -39,7 +39,7 @@ internal class FragmentStoreFormula(
         }
     }
 
-    fun fragmentRemoved(fragmentId: FragmentId) {
+    fun fragmentRemoved(fragmentId: FragmentId<*>) {
         stateChanges.tryEmit {
             val updated = state.copy(
                 activeIds = state.activeIds.minus(fragmentId),
@@ -50,7 +50,7 @@ internal class FragmentStoreFormula(
         }
     }
 
-    fun fragmentVisible(fragmentId: FragmentId) {
+    fun fragmentVisible(fragmentId: FragmentId<*>) {
         stateChanges.tryEmit {
             if (state.visibleIds.contains(fragmentId)) {
                 // TODO: should we log this duplicate visibility event?
@@ -61,7 +61,7 @@ internal class FragmentStoreFormula(
         }
     }
 
-    fun fragmentHidden(fragmentId: FragmentId) {
+    fun fragmentHidden(fragmentId: FragmentId<*>) {
         stateChanges.tryEmit {
             transition(state.copy(visibleIds = state.visibleIds.minus(fragmentId)))
         }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/InternalExtensions.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/InternalExtensions.kt
@@ -13,7 +13,7 @@ internal inline fun <T> List<T>.forEachIndices(action: (T) -> Unit) {
     }
 }
 
-internal fun Map<FragmentId, FeatureEvent>.getViewFactory(environment: FragmentEnvironment, fragmentId: FragmentId): ViewFactory<Any>? {
+internal fun Map<FragmentId<*>, FeatureEvent>.getViewFactory(environment: FragmentEnvironment, fragmentId: FragmentId<*>): ViewFactory<Any>? {
     return try {
         findViewFactoryOrThrow(fragmentId)
     } catch (e: Throwable) {
@@ -22,8 +22,8 @@ internal fun Map<FragmentId, FeatureEvent>.getViewFactory(environment: FragmentE
     }
 }
 
-private fun Map<FragmentId, FeatureEvent>.findViewFactoryOrThrow(
-    fragmentId: FragmentId
+private fun Map<FragmentId<*>, FeatureEvent>.findViewFactoryOrThrow(
+    fragmentId: FragmentId<*>
 ): ViewFactory<Any> {
     val key = fragmentId.key
     val featureEvent = this[fragmentId] ?: throw IllegalStateException("Could not find feature for $key.")

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/MappedFeatureFactory.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/MappedFeatureFactory.kt
@@ -13,7 +13,6 @@ internal class MappedFeatureFactory<Component, Dependencies, Key : FragmentKey>(
         return delegate.initialize(
             dependencies = toDependencies(dependencies),
             fragmentId = fragmentId,
-            key = key,
         )
     }
 }

--- a/formula-android/src/main/java/com/instacart/formula/android/internal/StateFlowFeatureAction.kt
+++ b/formula-android/src/main/java/com/instacart/formula/android/internal/StateFlowFeatureAction.kt
@@ -19,7 +19,7 @@ import kotlinx.coroutines.withContext
 class StateFlowFeatureAction internal constructor(
     private val asyncDispatcher: CoroutineDispatcher,
     private val fragmentEnvironment: FragmentEnvironment,
-    private val fragmentId: FragmentId,
+    private val fragmentId: FragmentId<*>,
     private val feature: StateFlowFeature,
 ) : Action<Any> {
 

--- a/formula-android/src/test/java/com/instacart/formula/android/fakes/StateFlowFeatureFactory.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/fakes/StateFlowFeatureFactory.kt
@@ -9,7 +9,7 @@ import com.instacart.testutils.android.StateFlowKey
 import com.instacart.testutils.android.TestViewFactory
 
 class StateFlowFeatureFactory(
-    private val formula: IFormula<FragmentId, Any>
+    private val formula: IFormula<FragmentId<*>, Any>
 ) : FeatureFactory<Unit, StateFlowKey>() {
     override fun Params.initialize(): Feature {
         return Feature(

--- a/formula-android/src/test/java/com/instacart/formula/android/fakes/StateFlowFormula.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/fakes/StateFlowFormula.kt
@@ -7,7 +7,7 @@ import com.instacart.formula.Snapshot
 import com.instacart.formula.android.FragmentId
 import kotlinx.coroutines.flow.MutableSharedFlow
 
-class StateFlowFormula: Formula<FragmentId, String, String>() {
+class StateFlowFormula: Formula<FragmentId<*>, String, String>() {
     private val sharedFlow = MutableSharedFlow<Pair<String, String>>(
         extraBufferCapacity = Int.MAX_VALUE,
     )
@@ -16,11 +16,11 @@ class StateFlowFormula: Formula<FragmentId, String, String>() {
         sharedFlow.tryEmit(instanceId to state)
     }
 
-    override fun initialState(input: FragmentId): String {
+    override fun initialState(input: FragmentId<*>): String {
         return ""
     }
 
-    override fun Snapshot<FragmentId, String>.evaluate(): Evaluation<String> {
+    override fun Snapshot<FragmentId<*>, String>.evaluate(): Evaluation<String> {
         return Evaluation(
             output = state,
             actions = context.actions {

--- a/formula-android/src/test/java/com/instacart/formula/android/internal/GetViewFactoryTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/android/internal/GetViewFactoryTest.kt
@@ -20,7 +20,7 @@ class GetViewFactoryTest {
         )
 
         val fragmentId = FragmentId("test", MainKey(1))
-        val features = mapOf<FragmentId, FeatureEvent>()
+        val features = mapOf<FragmentId<*>, FeatureEvent>()
 
         val viewFactory = features.getViewFactory(environment, fragmentId)
         assertThat(viewFactory).isNull()
@@ -37,7 +37,7 @@ class GetViewFactoryTest {
         )
 
         val fragmentId = FragmentId("test", MainKey(1))
-        val features = mapOf(
+        val features: Map<FragmentId<*>, FeatureEvent> = mapOf(
             fragmentId to FeatureEvent.MissingBinding(
                 id = fragmentId,
             )
@@ -58,7 +58,7 @@ class GetViewFactoryTest {
         )
 
         val fragmentId = FragmentId("test", MainKey(1))
-        val features = mapOf(
+        val features: Map<FragmentId<*>, FeatureEvent> = mapOf(
             fragmentId to FeatureEvent.Failure(
                 id = fragmentId,
                 error = IllegalStateException("test")
@@ -76,7 +76,7 @@ class GetViewFactoryTest {
     @Test fun `getViewFactory returns valid view factory`() {
         val fragmentId = FragmentId("test", MainKey(1))
         val expectedViewFactory = TestViewFactory<Any>()
-        val features = mapOf(
+        val features: Map<FragmentId<*>, FeatureEvent> = mapOf(
             fragmentId to FeatureEvent.Init(
                 id = fragmentId,
                 feature = Feature(


### PR DESCRIPTION
## What
Re-adding generic type information to `FragmentId`. This enables us to pass only `FragmentId<MyFragmentKey>` instead of both `FragmentId` and `MyFragmentKey`.