### PR TITLE
Isolating formula evaluation error handling.

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -94,20 +94,6 @@ abstract class FormulaContext<out Input, State> internal constructor(
     }
 
     /**
-     * A convenience method to run a formula that takes no input. Returns the latest output of
-     * the [child] formula or null if the child formula has encountered an exception. Child formulas
-     * that encounter exceptions will be be terminated and will not be run again. Formula runtime
-     * ensures the [formula] is running, manages its internal state and will trigger `evaluate`
-     * if needed.
-     */
-    fun <ChildOutput> child(
-        formula: IFormula<Unit, ChildOutput>,
-        onError: (Throwable) -> Unit,
-    ): ChildOutput? {
-        return child(formula, Unit, onError)
-    }
-
-    /**
      * Returns the latest output of the [child] formula. Formula runtime ensures the [child]
      * is running, manages its internal state and will trigger `evaluate` if needed.
      */
@@ -117,15 +103,27 @@ abstract class FormulaContext<out Input, State> internal constructor(
     ): ChildOutput
 
     /**
+     * A convenience method to run a formula that takes no input. Returns the latest output of
+     * the [child] formula or null if the child formula has encountered an exception. Child formulas
+     * that encounter exceptions will be be terminated and will not be run again. Formula runtime
+     * ensures the [formula] is running, manages its internal state and will trigger `evaluate`
+     * if needed.
+     */
+    fun <ChildOutput> childOrNull(
+        formula: IFormula<Unit, ChildOutput>
+    ): ChildOutput? {
+        return childOrNull(formula, Unit)
+    }
+
+    /**
      * Returns the latest output of the [child] formula or null if the child formula has encountered
      * an exception. Child formulas that encounter exceptions will be be terminated and will not
      * be run again. Formula runtime ensures the [child] is running, manages its internal state
      * and will trigger `evaluate` if needed.
      */
-    abstract fun <ChildInput, ChildOutput> child(
+    abstract fun <ChildInput, ChildOutput> childOrNull(
         formula: IFormula<ChildInput, ChildOutput>,
         input: ChildInput,
-        onError: (Throwable) -> Unit,
     ): ChildOutput?
 
     /**

--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -86,6 +86,11 @@ abstract class FormulaContext<out Input, State> internal constructor(
      * A convenience method to run a formula that takes no input. Returns the latest output
      * of the [formula] formula. Formula runtime ensures the [formula] is running, manages
      * its internal state and will trigger `evaluate` if needed.
+     *
+     * ### Error Handling
+     * When encountering exceptions within child formula, it will first terminate the child
+     * formula and notify [FormulaPlugins.onError]. Then, if possible, it will return the
+     * last [ChildOutput]. Otherwise, it will throw an error, propagating it up the chain.
      */
     fun <ChildOutput> child(
         formula: IFormula<Unit, ChildOutput>
@@ -96,6 +101,11 @@ abstract class FormulaContext<out Input, State> internal constructor(
     /**
      * Returns the latest output of the [child] formula. Formula runtime ensures the [child]
      * is running, manages its internal state and will trigger `evaluate` if needed.
+     *
+     * ### Error Handling
+     * When encountering exceptions within child formula, it will first terminate the child
+     * formula and notify [FormulaPlugins.onError]. Then, if possible, it will return the
+     * last [ChildOutput]. Otherwise, it will throw an error, propagating it up the chain.
      */
     abstract fun <ChildInput, ChildOutput> child(
         formula: IFormula<ChildInput, ChildOutput>,

--- a/formula/src/main/java/com/instacart/formula/internal/CascadingFormulaException.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/CascadingFormulaException.kt
@@ -1,0 +1,8 @@
+package com.instacart.formula.internal
+
+/**
+ * Indicates a formula exception that could not be isolated and is
+ * cascaded up the tree. The global error listener has already been
+ * notified, so there's no need to log it again.
+ */
+class CascadingFormulaException(cause: Throwable) : RuntimeException(cause)

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManager.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.internal
 
-import com.instacart.formula.Evaluation
 import com.instacart.formula.Formula
 
 interface FormulaManager<Input, Output> {
@@ -17,7 +16,12 @@ interface FormulaManager<Input, Output> {
      *
      * It will handle formula state changes internally and return the last [Output].
      */
-    fun run(input: Input): Evaluation<Output>
+    fun run(input: Input): Output
+
+    /**
+     * Returns the last output produced by the formula or null.
+     */
+    fun lastOutput(): Output?
 
     fun isTerminated(): Boolean
 

--- a/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/FormulaManagerImpl.kt
@@ -253,7 +253,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
         val manager = childrenManager.findOrInitChild(key, formula, input)
 
         if (manager.isTerminated()) {
-            manager.lastOutput() ?: run {
+            return manager.lastOutput() ?: run {
                 /**
                  * This block should never be reached as we should have been terminated as well.
                  */

--- a/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
@@ -44,10 +44,9 @@ internal class SnapshotImpl<out Input, State>(
         return delegate.child(key, formula, input)
     }
 
-    override fun <ChildInput, ChildOutput> child(
+    override fun <ChildInput, ChildOutput> childOrNull(
         formula: IFormula<ChildInput, ChildOutput>,
         input: ChildInput,
-        onError: (Throwable) -> Unit,
     ): ChildOutput? {
         ensureNotRunning()
 
@@ -55,7 +54,7 @@ internal class SnapshotImpl<out Input, State>(
             type = formula.type(),
             key = formula.key(input)
         )
-        return delegate.child(key, formula, input, onError)
+        return delegate.childOrNull(key, formula, input)
     }
 
     override fun <Event> eventListener(

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -1421,7 +1421,7 @@ class FormulaRuntimeTest {
         }
 
         // No errors
-        val error = result.errorOrNull()?.cause
+        val error = result.errorOrNull()
         assertThat(error).isNull()
     }
 
@@ -1434,7 +1434,7 @@ class FormulaRuntimeTest {
         }
 
         // No errors
-        val error = result.errorOrNull()?.cause
+        val error = result.errorOrNull()
         assertThat(error).isNull()
 
         // Should log only once
@@ -1786,11 +1786,13 @@ class FormulaRuntimeTest {
                 }
             }
         val formula = HasChildrenFormula(childCount = 3, childFormula)
-        formula.test().input(0)
+        val observer = formula.test(failOnError = false)
+            .input(0)
             .output {
                 assertThat(childOutputs).isEqualTo(listOf(0, 2))
-                assertThat(errors).hasSize(1)
             }
+
+        assertThat(observer.errors()).hasSize(1)
     }
 
     @Test
@@ -1810,11 +1812,14 @@ class FormulaRuntimeTest {
                 }
             }
         val formula = HasChildrenFormula(childCount = 3, childFormula)
-        formula.test().input(0)
+        val observer = formula.test(failOnError = false)
+        observer
+            .input(0)
             .output {
                 assertThat(childOutputs).isEqualTo(listOf(0, 2))
-                assertThat(errors).hasSize(1)
             }
+
+        assertThat(observer.errors()).hasSize(1)
     }
 
     @Test
@@ -1834,7 +1839,7 @@ class FormulaRuntimeTest {
                 )
             },
         )
-        formula.test().input(0)
+        formula.test(failOnError = false).input(0)
             .output {
                 childOutputs.forEach { it.listener() }
                 childOutputs[1].errorToggle()


### PR DESCRIPTION
## What
Instead of always propagating formula errors up to the top (unless `onError` is provided with `child`), we are updating API to be a bit more resilient:
- Automatically log all formula errors with the global error handler
- Replace child `onError` API with `childOrNull` (it will automatically log the error)
- Regular `child` function will return the last computed output value or propagate the error up to the parent formula. In many cases, the failure will be isolated to the first two layers.