### PR TITLE
Use Class<*> instead of KClass<*> consistently.

### DIFF
--- a/formula-android/src/test/java/com/instacart/formula/MockitoFormulaTest.kt
+++ b/formula-android/src/test/java/com/instacart/formula/MockitoFormulaTest.kt
@@ -13,7 +13,7 @@ class MockitoFormulaTest {
         val formula = mock<MyFormula>(defaultAnswer = CallsRealMethods())
         whenever(formula.implementation).thenReturn(testFormula)
         assertThat(formula.implementation).isEqualTo(testFormula)
-        assertThat(formula.type()).isEqualTo(MyFormula::class)
+        assertThat(formula.type()).isEqualTo(MyFormula::class.java)
     }
 
     @Test fun mockActionFormula() {
@@ -21,7 +21,7 @@ class MockitoFormulaTest {
         val formula = mock<MyActionFormula>(defaultAnswer = CallsRealMethods())
         whenever(formula.implementation).thenReturn(testFormula)
         assertThat(formula.implementation).isEqualTo(testFormula)
-        assertThat(formula.type()).isEqualTo(MyActionFormula::class)
+        assertThat(formula.type()).isEqualTo(MyActionFormula::class.java)
     }
 
     class MyFormula : StatelessFormula<Unit, Unit>() {

--- a/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/CountingInspector.kt
@@ -11,9 +11,9 @@ class CountingInspector : Inspector {
     private val actionsStarted = mutableListOf<Class<*>>()
     private val stateTransitions = mutableListOf<Class<*>>()
 
-    override fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) {
+    override fun onEvaluateFinished(formulaType: Class<*>, output: Any?, evaluated: Boolean) {
         if (evaluated) {
-            evaluatedList.add(formulaType.java)
+            evaluatedList.add(formulaType)
         }
     }
 
@@ -21,12 +21,12 @@ class CountingInspector : Inspector {
         runCount += 1
     }
 
-    override fun onActionStarted(formulaType: KClass<*>, action: DeferredAction<*>) {
-        actionsStarted.add(formulaType.java)
+    override fun onActionStarted(formulaType: Class<*>, action: DeferredAction<*>) {
+        actionsStarted.add(formulaType)
     }
 
-    override fun onStateChanged(formulaType: KClass<*>, event: Any?, old: Any?, new: Any?) {
-        stateTransitions.add(formulaType.java)
+    override fun onStateChanged(formulaType: Class<*>, event: Any?, old: Any?, new: Any?) {
+        stateTransitions.add(formulaType)
     }
 
     fun assertEvaluationCount(expected: Int) = apply {

--- a/formula-test/src/test/java/com/instacart/formula/test/CountingInspectorTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/CountingInspectorTest.kt
@@ -23,7 +23,7 @@ class CountingInspectorTest {
     fun `assertEvaluationCount with types throws exception when count does not match`() {
         val inspector = CountingInspector()
         inspector.assertEvaluationCount(MyFormula::class, 0)
-        inspector.onEvaluateFinished(MyFormula::class, null, true)
+        inspector.onEvaluateFinished(MyFormula::class.java, null, true)
         inspector.assertEvaluationCount(MyFormula::class, 1)
 
         val result = runCatching { inspector.assertEvaluationCount(MyFormula::class, 5) }
@@ -58,7 +58,7 @@ class CountingInspectorTest {
     fun `assertStateTransitions throws exception when count does not match`() {
         val inspector = CountingInspector()
         inspector.assertStateTransitions(MyFormula::class, 0)
-        inspector.onStateChanged(MyFormula::class, null, null, null)
+        inspector.onStateChanged(MyFormula::class.java, null, null, null)
         inspector.assertStateTransitions(MyFormula::class, 1)
 
         val result = runCatching { inspector.assertStateTransitions(MyFormula::class, 5) }

--- a/formula/src/main/java/com/instacart/formula/FormulaContext.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaContext.kt
@@ -164,5 +164,5 @@ abstract class FormulaContext<out Input, State> internal constructor(
     // Internal key scope management
     @PublishedApi internal abstract fun enterScope(key: Any)
     @PublishedApi internal abstract fun endScope()
-    @PublishedApi internal abstract fun createScopedKey(type: KClass<*>, key: Any?): Any
+    @PublishedApi internal abstract fun createScopedKey(type: Class<*>, key: Any?): Any
 }

--- a/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaPlugins.kt
@@ -1,6 +1,6 @@
 package com.instacart.formula
 
-import com.instacart.formula.internal.ListInspector
+import com.instacart.formula.plugin.ListInspector
 import com.instacart.formula.plugin.Dispatcher
 import com.instacart.formula.plugin.FormulaError
 import com.instacart.formula.plugin.Inspector
@@ -14,7 +14,7 @@ object FormulaPlugins {
         this.plugin = plugin
     }
 
-    fun inspector(type: KClass<*>, local: Inspector?): Inspector? {
+    fun inspector(type: Class<*>, local: Inspector?): Inspector? {
         val global = plugin?.inspector(type)
         return when {
             global == null -> local

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -397,9 +397,9 @@ class FormulaRuntime<Input : Any, Output : Any>(
 
     private fun initManager(initialInput: Input): FormulaManagerImpl<Input, *, Output> {
         return FormulaManagerImpl(
-            formulaTypeKClass = formula.type(),
             delegate = this,
             formula = implementation,
+            formulaType = formula.type(),
             initialInput = initialInput,
         )
     }

--- a/formula/src/main/java/com/instacart/formula/IFormula.kt
+++ b/formula/src/main/java/com/instacart/formula/IFormula.kt
@@ -27,7 +27,7 @@ interface IFormula<in Input, out Output> {
      * instance. This method allows us to preserve the original identity of formula
      * when using delegation and composition.
      */
-    fun type(): KClass<*> = this::class
+    fun type(): Class<*> = this::class.java
 
     /**
      * A unique identifier used to distinguish formulas of the same type. This can also

--- a/formula/src/main/java/com/instacart/formula/Transition.kt
+++ b/formula/src/main/java/com/instacart/formula/Transition.kt
@@ -110,7 +110,7 @@ fun interface Transition<in Input, State, in Event> {
     /**
      * Transition type is used as part of the key to distinguish different transitions.
      */
-    fun type(): KClass<*> {
-        return this::class
+    fun type(): Class<*> {
+        return this::class.java
     }
 }

--- a/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ActionManager.kt
@@ -87,7 +87,7 @@ internal class ActionManager(
 
             val runningActions = getOrInitRunningActions()
             if (!runningActions.contains(action)) {
-                inspector?.onActionStarted(manager.formulaTypeKClass, action)
+                inspector?.onActionStarted(manager.formulaType, action)
 
                 runningActions.add(action)
                 action.start(manager)
@@ -148,7 +148,7 @@ internal class ActionManager(
     }
 
     private fun finishAction(action: DeferredAction<*>) {
-        inspector?.onActionFinished(manager.formulaTypeKClass, action)
+        inspector?.onActionFinished(manager.formulaType, action)
         action.tearDown(manager)
     }
 

--- a/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/ChildrenManager.kt
@@ -70,7 +70,7 @@ internal class ChildrenManager(
                 val error = FormulaError.ChildKeyAlreadyUsed(
                     error = ChildAlreadyUsedException(
                         parentType = manager.formulaType,
-                        childType = formula.type().java,
+                        childType = formula.type(),
                         key = key
                     )
                 )
@@ -101,9 +101,9 @@ internal class ChildrenManager(
         val childFormulaHolder = children.findOrInit(key) {
             val implementation = formula.implementation
             FormulaManagerImpl(
-                formulaTypeKClass = formula.type(),
                 delegate = manager,
                 formula = implementation,
+                formulaType = formula.type(),
                 initialInput = input,
             )
         }

--- a/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/internal/SnapshotImpl.kt
@@ -9,7 +9,6 @@ import com.instacart.formula.Snapshot
 import com.instacart.formula.Transition
 import com.instacart.formula.TransitionContext
 import java.lang.IllegalStateException
-import kotlin.reflect.KClass
 
 internal class SnapshotImpl<out Input, State>(
     private val delegate: FormulaManagerImpl<Input, State, *>,
@@ -86,15 +85,15 @@ internal class SnapshotImpl<out Input, State>(
         scopeKey = lastKey
     }
 
-    override fun createScopedKey(type: KClass<*>, key: Any?): Any {
+    override fun createScopedKey(type: Class<*>, key: Any?): Any {
         if (scopeKey == null && key == null) {
             // No need to allocate a new object, just use type as key.
-            return type.java
+            return type
         }
 
         return FormulaKey(
             scopeKey = scopeKey,
-            type = type.java,
+            type = type,
             key = key,
         )
     }

--- a/formula/src/main/java/com/instacart/formula/plugin/Inspector.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/Inspector.kt
@@ -13,21 +13,21 @@ interface Inspector {
      *
      * @param formulaType Formula type used to filter for specific events.
      */
-    fun onFormulaStarted(formulaType: KClass<*>) = Unit
+    fun onFormulaStarted(formulaType: Class<*>) = Unit
 
     /**
      * Called when Formula or child formula is finished.
      *
      * @param formulaType Formula type used to filter for specific events.
      */
-    fun onFormulaFinished(formulaType: KClass<*>) = Unit
+    fun onFormulaFinished(formulaType: Class<*>) = Unit
 
     /**
      * Called when Formula evaluation is started.
      *
      * @param formulaType Formula type used to filter for specific events.
      */
-    fun onEvaluateStarted(formulaType: KClass<*>, state: Any?) = Unit
+    fun onEvaluateStarted(formulaType: Class<*>, state: Any?) = Unit
 
     /**
      * Called when Formula input has changed.
@@ -36,7 +36,7 @@ interface Inspector {
      * @param prevInput Previous input used
      * @param newInput New input value
      */
-    fun onInputChanged(formulaType: KClass<*>, prevInput: Any?, newInput: Any?) = Unit
+    fun onInputChanged(formulaType: Class<*>, prevInput: Any?, newInput: Any?) = Unit
 
     /**
      * Called when Formula evaluation is finished.
@@ -44,7 +44,7 @@ interface Inspector {
      * @param formulaType Formula type used to filter for specific events.
      * @param evaluated Indicates if evaluate had to run. If false, this means that we re-used previous output.
      */
-    fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) = Unit
+    fun onEvaluateFinished(formulaType: Class<*>, output: Any?, evaluated: Boolean) = Unit
 
     /**
      * Called when an action is started.
@@ -52,7 +52,7 @@ interface Inspector {
      * @param formulaType Formula type used to filter for specific events.
      * @param action Action that was started.
      */
-    fun onActionStarted(formulaType: KClass<*>, action: DeferredAction<*>) = Unit
+    fun onActionStarted(formulaType: Class<*>, action: DeferredAction<*>) = Unit
 
     /**
      * Called when an action is finished.
@@ -60,7 +60,7 @@ interface Inspector {
      * @param formulaType Formula type used to filter for specific events.
      * @param action Action that was finished.
      */
-    fun onActionFinished(formulaType: KClass<*>, action: DeferredAction<*>) = Unit
+    fun onActionFinished(formulaType: Class<*>, action: DeferredAction<*>) = Unit
 
     /**
      * Called when a state change happens
@@ -70,7 +70,7 @@ interface Inspector {
      * @param old Previous state value
      * @param new New state value
      */
-    fun onStateChanged(formulaType: KClass<*>, event: Any?, old: Any?, new: Any?) = Unit
+    fun onStateChanged(formulaType: Class<*>, event: Any?, old: Any?, new: Any?) = Unit
 
     /**
      * Called when [FormulaRuntime.run] is called. This method in combination with [onRunFinished]

--- a/formula/src/main/java/com/instacart/formula/plugin/ListInspector.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/ListInspector.kt
@@ -1,41 +1,40 @@
-package com.instacart.formula.internal
+package com.instacart.formula.plugin
 
 import com.instacart.formula.DeferredAction
-import com.instacart.formula.plugin.Inspector
 import kotlin.reflect.KClass
 
-internal class ListInspector(
+class ListInspector(
     private val inspectors: List<Inspector>,
 ) : Inspector {
-    override fun onFormulaStarted(formulaType: KClass<*>) {
+    override fun onFormulaStarted(formulaType: Class<*>) {
         forEachInspector { onFormulaStarted(formulaType) }
     }
 
-    override fun onFormulaFinished(formulaType: KClass<*>) {
+    override fun onFormulaFinished(formulaType: Class<*>) {
         forEachInspector { onFormulaFinished(formulaType) }
     }
 
-    override fun onEvaluateStarted(formulaType: KClass<*>, state: Any?) {
+    override fun onEvaluateStarted(formulaType: Class<*>, state: Any?) {
         forEachInspector { onEvaluateStarted(formulaType, state) }
     }
 
-    override fun onInputChanged(formulaType: KClass<*>, prevInput: Any?, newInput: Any?) {
+    override fun onInputChanged(formulaType: Class<*>, prevInput: Any?, newInput: Any?) {
         forEachInspector { onInputChanged(formulaType, prevInput, newInput) }
     }
 
-    override fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) {
+    override fun onEvaluateFinished(formulaType: Class<*>, output: Any?, evaluated: Boolean) {
         forEachInspector { onEvaluateFinished(formulaType, output, evaluated) }
     }
 
-    override fun onActionStarted(formulaType: KClass<*>, action: DeferredAction<*>) {
+    override fun onActionStarted(formulaType: Class<*>, action: DeferredAction<*>) {
         forEachInspector { onActionStarted(formulaType, action) }
     }
 
-    override fun onActionFinished(formulaType: KClass<*>, action: DeferredAction<*>) {
+    override fun onActionFinished(formulaType: Class<*>, action: DeferredAction<*>) {
         forEachInspector { onActionFinished(formulaType, action) }
     }
 
-    override fun onStateChanged(formulaType: KClass<*>, event: Any?, old: Any?, new: Any?) {
+    override fun onStateChanged(formulaType: Class<*>, event: Any?, old: Any?, new: Any?) {
         forEachInspector { onStateChanged(formulaType, event, old, new) }
     }
 

--- a/formula/src/main/java/com/instacart/formula/plugin/Plugin.kt
+++ b/formula/src/main/java/com/instacart/formula/plugin/Plugin.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.plugin
 
-import kotlin.reflect.KClass
 
 interface Plugin {
     /**
@@ -9,7 +8,7 @@ interface Plugin {
      *
      * @param type Formula type.
      */
-    fun inspector(type: KClass<*>): Inspector? {
+    fun inspector(type: Class<*>): Inspector? {
         return null
     }
 

--- a/formula/src/test/java/com/instacart/formula/FormulaPluginTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaPluginTest.kt
@@ -86,7 +86,7 @@ class FormulaPluginTest {
             observer.assertHasErrors()
 
             assertThat(plugin.errors).containsExactly(
-                FormulaError.ActionError(myFormula.type().java, exception)
+                FormulaError.ActionError(myFormula.type(), exception)
             )
         }
     }

--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -101,7 +101,6 @@ import org.junit.rules.RuleChain
 import org.junit.rules.TestName
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executors
-import kotlin.reflect.KClass
 
 class FormulaRuntimeTest {
 
@@ -2032,7 +2031,7 @@ class FormulaRuntimeTest {
     fun `inspector events`() {
         val globalInspector = TestInspector()
         FormulaPlugins.setPlugin(object : Plugin {
-            override fun inspector(type: KClass<*>): Inspector {
+            override fun inspector(type: Class<*>): Inspector {
                 return globalInspector
             }
         })
@@ -2073,7 +2072,7 @@ class FormulaRuntimeTest {
         val localInspector = TestInspector()
         val globalInspector = TestInspector()
         FormulaPlugins.setPlugin(object : Plugin {
-            override fun inspector(type: KClass<*>): Inspector {
+            override fun inspector(type: Class<*>): Inspector {
                 return globalInspector
             }
         })
@@ -2116,7 +2115,7 @@ class FormulaRuntimeTest {
     fun `only global inspector events`() {
         val globalInspector = TestInspector()
         FormulaPlugins.setPlugin(object : Plugin {
-            override fun inspector(type: KClass<*>): Inspector {
+            override fun inspector(type: Class<*>): Inspector {
                 return globalInspector
             }
         })
@@ -2423,7 +2422,7 @@ class FormulaRuntimeTest {
     @Test fun `batched events notify the inspector of start and stop`() {
         val globalInspector = TestInspector()
         FormulaPlugins.setPlugin(object : Plugin {
-            override fun inspector(type: KClass<*>): Inspector {
+            override fun inspector(type: Class<*>): Inspector {
                 return globalInspector
             }
         })

--- a/formula/src/test/java/com/instacart/formula/StateFlowRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/StateFlowRuntimeTest.kt
@@ -169,7 +169,7 @@ class StateFlowRuntimeTest {
             runCatching { formula.runAsStateFlow(backgroundScope) }
 
             assertThat(plugin.errors).containsExactly(
-                FormulaError.Unhandled(formula.type().java, error)
+                FormulaError.Unhandled(formula.type(), error)
             )
         }
     }

--- a/formula/src/test/java/com/instacart/formula/internal/TestInspector.kt
+++ b/formula/src/test/java/com/instacart/formula/internal/TestInspector.kt
@@ -17,44 +17,44 @@ class TestInspector : Inspector {
         events.add("formula-run-finished")
     }
 
-    override fun onFormulaStarted(formulaType: KClass<*>) {
+    override fun onFormulaStarted(formulaType: Class<*>) {
         super.onFormulaStarted(formulaType)
-        events.add("formula-started: ${formulaType.qualifiedName}")
+        events.add("formula-started: ${name(formulaType)}")
     }
 
-    override fun onEvaluateStarted(formulaType: KClass<*>, state: Any?) {
+    override fun onEvaluateStarted(formulaType: Class<*>, state: Any?) {
         super.onEvaluateStarted(formulaType, state)
-        events.add("evaluate-started: ${formulaType.qualifiedName}")
+        events.add("evaluate-started: ${name(formulaType)}")
     }
 
-    override fun onEvaluateFinished(formulaType: KClass<*>, output: Any?, evaluated: Boolean) {
+    override fun onEvaluateFinished(formulaType: Class<*>, output: Any?, evaluated: Boolean) {
         super.onEvaluateFinished(formulaType, output, evaluated)
-        events.add("evaluate-finished: ${formulaType.qualifiedName}")
+        events.add("evaluate-finished: ${name(formulaType)}")
     }
 
-    override fun onActionStarted(formulaType: KClass<*>, action: DeferredAction<*>) {
+    override fun onActionStarted(formulaType: Class<*>, action: DeferredAction<*>) {
         super.onActionStarted(formulaType, action)
-        events.add("action-started: ${formulaType.qualifiedName}")
+        events.add("action-started: ${name(formulaType)}")
     }
 
-    override fun onActionFinished(formulaType: KClass<*>, action: DeferredAction<*>) {
+    override fun onActionFinished(formulaType: Class<*>, action: DeferredAction<*>) {
         super.onActionFinished(formulaType, action)
-        events.add("action-finished: ${formulaType.qualifiedName}")
+        events.add("action-finished: ${name(formulaType)}")
     }
 
-    override fun onInputChanged(formulaType: KClass<*>, prevInput: Any?, newInput: Any?) {
+    override fun onInputChanged(formulaType: Class<*>, prevInput: Any?, newInput: Any?) {
         super.onInputChanged(formulaType, prevInput, newInput)
-        events.add("input-changed: ${formulaType.qualifiedName}")
+        events.add("input-changed: ${name(formulaType)}")
     }
 
-    override fun onStateChanged(formulaType: KClass<*>, event: Any?, old: Any?, new: Any?) {
+    override fun onStateChanged(formulaType: Class<*>, event: Any?, old: Any?, new: Any?) {
         super.onStateChanged(formulaType, event, old, new)
-        events.add("state-changed: ${formulaType.qualifiedName}")
+        events.add("state-changed: ${name(formulaType)}")
     }
 
-    override fun onFormulaFinished(formulaType: KClass<*>) {
+    override fun onFormulaFinished(formulaType: Class<*>) {
         super.onFormulaFinished(formulaType)
-        events.add("formula-finished: ${formulaType.qualifiedName}")
+        events.add("formula-finished: ${name(formulaType)}")
     }
 
     override fun onBatchStarted(updateCount: Int) {
@@ -65,5 +65,14 @@ class TestInspector : Inspector {
     override fun onBatchFinished() {
         super.onBatchFinished()
         events.add("batch-finished")
+    }
+
+    private fun name(formula: Class<*>): String {
+        val simpleName = formula.simpleName
+        return if (simpleName.isNotEmpty()) {
+            "${formula.packageName}.$simpleName"
+        } else {
+            "null"
+        }
     }
 }

--- a/formula/src/test/java/com/instacart/formula/subjects/TerminateFormula.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/TerminateFormula.kt
@@ -30,10 +30,10 @@ class TerminateFormula : StatelessFormula<Unit, Unit>() {
 
     internal class WithId<Input, State, Output>(
         override val implementation: Formula<Input, State, Output>,
-        val type: KClass<*>,
+        val type: Class<*>,
         val key: Any
     ) : IFormula<Input, Output> {
-        override fun type(): KClass<*> = type
+        override fun type(): Class<*> = type
 
         override fun key(input: Input): Any = key
     }


### PR DESCRIPTION
## What
Use `Class<*>` instead of `KClass<*>` across various APIs