### PR TITLE
coroutineScheduler support within TestFormulaObserver

### DIFF
--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -13,14 +13,18 @@ import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 
-@OptIn(DelicateCoroutinesApi::class)
+@OptIn(DelicateCoroutinesApi::class, ExperimentalCoroutinesApi::class)
 class TestFormulaObserver<Input : Any, Output : Any, FormulaT : IFormula<Input, Output>>(
     private val failOnError: Boolean,
     isValidationEnabled: Boolean,
     dispatcher: Dispatcher?,
     inspector: Inspector?,
     val formula: FormulaT,
+    coroutineScheduler: TestCoroutineScheduler = TestCoroutineScheduler(),
 ) {
     private val values = mutableListOf<Output>()
     private val errors = mutableListOf<Throwable>()
@@ -39,7 +43,7 @@ class TestFormulaObserver<Input : Any, Output : Any, FormulaT : IFormula<Input, 
     )
 
     private val job = GlobalScope.launch(
-        context = Dispatchers.Unconfined,
+        context = UnconfinedTestDispatcher(coroutineScheduler),
         start = CoroutineStart.UNDISPATCHED,
     ) {
         formula.toFlow(inputFlow, runtimeConfig)

--- a/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestFormulaObserver.kt
@@ -7,7 +7,6 @@ import com.instacart.formula.plugin.Inspector
 import com.instacart.formula.toFlow
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.DelicateCoroutinesApi
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.channels.BufferOverflow
 import kotlinx.coroutines.flow.MutableSharedFlow

--- a/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
+++ b/formula-test/src/main/java/com/instacart/formula/test/TestRuntimeExtensions.kt
@@ -2,7 +2,6 @@ package com.instacart.formula.test
 
 import com.instacart.formula.Action
 import com.instacart.formula.IFormula
-import com.instacart.formula.RuntimeConfig
 import com.instacart.formula.plugin.Dispatcher
 import com.instacart.formula.plugin.Inspector
 import kotlinx.coroutines.CoroutineDispatcher
@@ -25,6 +24,7 @@ fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
     failOnError: Boolean = true,
     inspector: Inspector? = null,
     dispatcher: Dispatcher? = null,
+    coroutineScheduler: TestCoroutineScheduler = TestCoroutineScheduler()
 ): TestFormulaObserver<Input, Output, F> {
     return TestFormulaObserver(
         isValidationEnabled = isValidationEnabled,
@@ -32,6 +32,7 @@ fun <Input : Any, Output : Any, F: IFormula<Input, Output>> F.test(
         inspector = inspector,
         dispatcher = dispatcher,
         formula = this,
+        coroutineScheduler = coroutineScheduler,
     )
 }
 

--- a/formula-test/src/test/java/com/instacart/formula/test/DelayFormula.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/DelayFormula.kt
@@ -1,0 +1,33 @@
+package com.instacart.formula.test
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlin.time.Duration
+
+class DelayFormula(
+    private val delay: Duration,
+) : Formula<Unit, DelayFormula.State, Int>() {
+    data class State(val count: Int = 0)
+
+    override fun initialState(input: Unit) = State()
+
+    override fun Snapshot<Unit, State>.evaluate(): Evaluation<Int> {
+        return Evaluation(
+            output = state.count,
+            actions = context.actions {
+                Action.fromFlow {
+                    flow {
+                        delay(delay)
+                        emit(1)
+                    }
+                }.onEvent {
+                    transition(state.copy(count = state.count + 1))
+                }
+            }
+        )
+    }
+}

--- a/formula-test/src/test/java/com/instacart/formula/test/TestCoroutineSchedulerIntegrationTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestCoroutineSchedulerIntegrationTest.kt
@@ -1,11 +1,6 @@
 package com.instacart.formula.test
 
-import com.instacart.formula.Action
-import com.instacart.formula.Evaluation
-import com.instacart.formula.Formula
-import com.instacart.formula.Snapshot
-import kotlinx.coroutines.delay
-import kotlinx.coroutines.flow.flow
+import com.google.common.truth.Truth
 import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -13,42 +8,43 @@ import kotlin.time.Duration.Companion.seconds
 
 class TestCoroutineSchedulerIntegrationTest {
 
-    private class DelayFormula : Formula<Unit, DelayFormula.State, Int>() {
-        data class State(val count: Int = 0)
-
-        override fun initialState(input: Unit) = State()
-
-        override fun Snapshot<Unit, State>.evaluate(): Evaluation<Int> {
-            return Evaluation(
-                output = state.count,
-                actions = context.actions {
-                    Action.fromFlow {
-                        flow {
-                            delay(1.seconds)
-                            emit(1)
-                        }
-                    }.onEvent {
-                        transition(state.copy(count = state.count + 1))
-                    }
-                }
-            )
-        }
-    }
-
     @Test
-    fun `TestCoroutineScheduler controls delay timing in formula actions`() = runTest {
+    fun `delay within action is advanced by scheduler`() = runTest {
         val scheduler = TestCoroutineScheduler()
-        val formula = DelayFormula()
+        val formula = DelayFormula(1.seconds)
         val observer = formula.test(coroutineScheduler = scheduler)
 
         observer.input(Unit)
-        observer.output { assert(this == 0) }
+        observer.output {
+            Truth.assertThat(this).isEqualTo(0)
+        }
 
-        // Advance virtual time by 2 seconds (longer than the 1-second delay)
         scheduler.advanceTimeBy(2.seconds)
 
-        // The action should have completed, incrementing count to 1
-        observer.output { assert(this == 1) }
+        observer.output {
+            Truth.assertThat(this).isEqualTo(1)
+        }
+
+        observer.dispose()
+    }
+
+    @Test
+    fun `delay within action is advanced by scheduler when infinite`() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        // basically forever
+        val formula = DelayFormula(Int.MAX_VALUE.seconds)
+        val observer = formula.test(coroutineScheduler = scheduler)
+
+        observer.input(Unit)
+        observer.output {
+            Truth.assertThat(this).isEqualTo(0)
+        }
+
+        scheduler.advanceUntilIdle()
+
+        observer.output {
+            Truth.assertThat(this).isEqualTo(1)
+        }
 
         observer.dispose()
     }

--- a/formula-test/src/test/java/com/instacart/formula/test/TestCoroutineSchedulerIntegrationTest.kt
+++ b/formula-test/src/test/java/com/instacart/formula/test/TestCoroutineSchedulerIntegrationTest.kt
@@ -1,0 +1,55 @@
+package com.instacart.formula.test
+
+import com.instacart.formula.Action
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestCoroutineScheduler
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import kotlin.time.Duration.Companion.seconds
+
+class TestCoroutineSchedulerIntegrationTest {
+
+    private class DelayFormula : Formula<Unit, DelayFormula.State, Int>() {
+        data class State(val count: Int = 0)
+
+        override fun initialState(input: Unit) = State()
+
+        override fun Snapshot<Unit, State>.evaluate(): Evaluation<Int> {
+            return Evaluation(
+                output = state.count,
+                actions = context.actions {
+                    Action.fromFlow {
+                        flow {
+                            delay(1.seconds)
+                            emit(1)
+                        }
+                    }.onEvent {
+                        transition(state.copy(count = state.count + 1))
+                    }
+                }
+            )
+        }
+    }
+
+    @Test
+    fun `TestCoroutineScheduler controls delay timing in formula actions`() = runTest {
+        val scheduler = TestCoroutineScheduler()
+        val formula = DelayFormula()
+        val observer = formula.test(coroutineScheduler = scheduler)
+
+        observer.input(Unit)
+        observer.output { assert(this == 0) }
+
+        // Advance virtual time by 2 seconds (longer than the 1-second delay)
+        scheduler.advanceTimeBy(2.seconds)
+
+        // The action should have completed, incrementing count to 1
+        observer.output { assert(this == 1) }
+
+        observer.dispose()
+    }
+}


### PR DESCRIPTION
## Key problem
If we have something like this in a formula:
```
Action.fromFlow {
    flow {
        delay(delay)
        emit(1)
    }
}.onEvent {
    transition(state.copy(count = state.count + 1))
}
```
then in tests, we don't currently have a way to "advance" time cleanly for the given formula action. 

## Solution
This adds a param to `TestFormulaObserver` so that we can pass in our own `TestCoroutineScheduler`. We can then call APIs such as `advanceTimeBy ` and `advanceUntilIdle` within our unit tests to simulate the passage of time, without having to actually wait the actual time with things like Thread.sleep.

```
val scheduler = TestCoroutineScheduler()
val observer = formula.test(coroutineScheduler = scheduler)
scheduler. advanceUntilIdle()
```
You can see the added `TestCoroutineSchedulerIntegrationTest` for a complete example.