### PR TITLE
[Benchmark] Add callback and inline transition benchmarks.

### DIFF
--- a/formula-performance/README.md
+++ b/formula-performance/README.md
@@ -85,6 +85,14 @@ open class MyBenchmark {
 - Critical for validating transition queue optimizations and child formula overhead
 - Run: `./gradlew :formula-performance:jmh -Pjmh=TransitionBenchmark`
 
+**TransitionQueueBenchmark** - Inline state transition queue processing overhead
+- Measures framework overhead for processing multiple inline state transitions
+- Tests with 1, 100, and 10,000 transitions to validate queue scaling behavior
+- Uses custom Action that emits events synchronously on start to exercise transitionQueue
+- Validates that `FormulaManagerImpl.transitionQueue` adds negligible overhead
+- Pure framework benchmark (trivial evaluation) - isolates queue processing cost
+- Run: `./gradlew :formula-performance:jmh -Pjmh=TransitionQueueBenchmark`
+
 ### ⏳ Planned Benchmarks
 
 #### Action Performance

--- a/formula-performance/src/jmh/kotlin/com/instacart/formula/benchmarks/CallbackOverheadBenchmark.kt
+++ b/formula-performance/src/jmh/kotlin/com/instacart/formula/benchmarks/CallbackOverheadBenchmark.kt
@@ -1,0 +1,96 @@
+package com.instacart.formula.benchmarks
+
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.test.TestFormulaObserver
+import com.instacart.formula.test.test
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+/**
+ * Benchmark for measuring state transition performance with many callback declarations.
+ *
+ * Tests how the overhead of declaring multiple callbacks affects transition performance.
+ * In real-world applications, formulas may have many callbacks for different UI interactions,
+ * and this benchmark measures whether having many callbacks impacts state change performance.
+ *
+ * Run with:
+ *   ./gradlew :formula-performance:jmh -Pjmh=CallbackOverheadBenchmark
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@State(Scope.Thread)
+open class CallbackOverheadBenchmark {
+
+    @Param("10", "50")
+    var callbackCount: Int = 10
+
+    private lateinit var observer: TestFormulaObserver<Int, CallbackOutput, *>
+
+    @Setup(Level.Iteration)
+    fun setup() {
+        observer = CallbackFormula().test(isValidationEnabled = false)
+    }
+
+    /**
+     * Triggers 100 transitions in succession with the specified callback count.
+     * JMH will report the average time per single transition.
+     */
+    @Benchmark
+    @OperationsPerInvocation(100)
+    fun transitions() {
+        observer.input(callbackCount)
+        repeat(100) {
+            observer.output { onIncrement() }
+        }
+    }
+
+    @TearDown(Level.Iteration)
+    fun tearDown() {
+        observer.dispose()
+    }
+
+    /**
+     * Formula that declares many callbacks to measure the overhead of callback declarations
+     * on state transition performance.
+     *
+     * Input: number of callbacks to declare
+     */
+    private class CallbackFormula : Formula<Int, Int, CallbackOutput>() {
+
+        override fun initialState(input: Int) = 0
+
+        override fun Snapshot<Int, Int>.evaluate(): Evaluation<CallbackOutput> {
+            // Create the increment callback that actually changes state
+            val onIncrement = context.callback {
+                transition(state + 1)
+            }
+
+            // Create a list of general callbacks that don't change state
+            val generalCallbacks = List(input) { index ->
+                context.callback(key = index) {
+                    // Transition that returns none (no state change)
+                    none()
+                }
+            }
+
+            return Evaluation(
+                output = CallbackOutput(
+                    count = state,
+                    onIncrement = onIncrement,
+                    generalCallbacks = generalCallbacks
+                )
+            )
+        }
+    }
+
+    private data class CallbackOutput(
+        val count: Int,
+        val onIncrement: () -> Unit,
+        val generalCallbacks: List<() -> Unit>,
+    )
+}

--- a/formula-performance/src/jmh/kotlin/com/instacart/formula/benchmarks/TransitionQueueBenchmark.kt
+++ b/formula-performance/src/jmh/kotlin/com/instacart/formula/benchmarks/TransitionQueueBenchmark.kt
@@ -1,0 +1,101 @@
+package com.instacart.formula.benchmarks
+
+import com.instacart.formula.Action
+import com.instacart.formula.Cancelable
+import com.instacart.formula.Evaluation
+import com.instacart.formula.Formula
+import com.instacart.formula.Snapshot
+import com.instacart.formula.test.TestFormulaObserver
+import com.instacart.formula.test.test
+import kotlinx.coroutines.CoroutineScope
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+/**
+ * Benchmark for testing transitionQueue behavior in FormulaManagerImpl.
+ *
+ * Tests the performance of inline state transitions when an action emits
+ * multiple events on start. This exercises the transitionQueue mechanism
+ * which queues up transitions while isRunning=true and processes them inline.
+ *
+ * Run with:
+ *   ./gradlew :formula-performance:jmh -Pjmh=TransitionQueueBenchmark
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Warmup(iterations = 3, time = 1, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 1, timeUnit = TimeUnit.SECONDS)
+@Fork(2)
+@State(Scope.Thread)
+open class TransitionQueueBenchmark {
+
+    private lateinit var observer: TestFormulaObserver<Int, Int, *>
+
+    @Setup(Level.Iteration)
+    fun setup() {
+        observer = MultiEventFormula().test(isValidationEnabled = false)
+        observer.input(0)
+    }
+
+    @Benchmark
+    fun measure1() {
+        observer.input(1)
+    }
+
+    @Benchmark
+    fun measure100() {
+        observer.input(100)
+    }
+
+    @Benchmark
+    fun measure10000() {
+        observer.input(10000)
+    }
+
+    @TearDown(Level.Iteration)
+    fun tearDown() {
+        observer.dispose()
+    }
+
+    /**
+     * Formula that uses an action which emits multiple events on start.
+     * This tests the transitionQueue behavior where events are queued and processed inline.
+     *
+     * Input: number of events to emit (0 means no action)
+     * Output: counter value from last event
+     */
+    private class MultiEventFormula : Formula<Int, Int, Int>() {
+
+        override fun initialState(input: Int) = 0
+
+        override fun Snapshot<Int, Int>.evaluate(): Evaluation<Int> {
+            return Evaluation(
+                output = state,
+                actions = context.actions {
+                    if (input > 0) {
+                        // Action that emits multiple events on start
+                        MultiEmitAction(input).onEvent { event ->
+                            transition(event)
+                        }
+                    }
+                }
+            )
+        }
+    }
+
+    /**
+     * Custom action that emits multiple events synchronously on start.
+     * All events are emitted immediately, causing them to queue up in transitionQueue.
+     */
+    private class MultiEmitAction(private val eventCount: Int) : Action<Int> {
+        override fun start(scope: CoroutineScope, emitter: Action.Emitter<Int>): Cancelable? {
+            // Emit multiple events synchronously - these will queue up in transitionQueue
+            for (i in 1..eventCount) {
+                emitter.onEvent(i)
+            }
+            return null
+        }
+
+        override fun key(): Any = eventCount
+    }
+}


### PR DESCRIPTION
## Description
Adding a couple more benchmarks:
- Benchmarking inline state changes happen during evaluation
- Benchmarking state transitions when formula has a lot of callbacks