### PR TITLE
Unbreak CI - pin full Ruby version.

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Install Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.3.10'
           bundler-cache: true
       - name: Run Core Tests
         run: ./gradlew :formula:test
@@ -78,7 +78,7 @@ jobs:
         if: github.event_name == 'pull_request'
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.3'
+          ruby-version: '3.3.10'
           bundler-cache: true
       - name: Report Benchmark Results (PR only)
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Fixes Ruby version mismatch on CI ([example](https://github.com/instacart/formula/actions/runs/25817958074/job/75851322143)): 
```
Your Ruby version is 3.3.11, but your Gemfile specified 3.3.10
```