### PR TITLE
[Performance] Use ArrayDeque for remaining LinkedList queues

### DIFF
--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -24,6 +24,15 @@ class FormulaRuntime<Input : Any, Output : Any>(
     private val formula: IFormula<Input, Output>,
     private val config: RuntimeConfig,
 ) : ManagerDelegate, BatchManager.Executor {
+    private companion object {
+        // Sized for the common case — a few effects per drain cycle. Stays under the stdlib
+        // default of 10 (which only kicks in on the no-arg constructor's first add).
+        private const val INITIAL_GLOBAL_EFFECT_QUEUE_CAPACITY = 8
+        // After a drain, replace the deque if we observed a burst this large. Picked well above
+        // typical cascading-transition depth so steady-state workloads never trigger a replace.
+        private const val GLOBAL_EFFECT_QUEUE_SHRINK_THRESHOLD = 64
+    }
+
     override val scope = CoroutineScope(
         context = coroutineContext + SupervisorJob(parent = coroutineContext[Job])
     )
@@ -80,8 +89,12 @@ class FormulaRuntime<Input : Any, Output : Any>(
 
     /**
      * Global transition effect queue which executes side-effects after all formulas are idle.
+     * Replaced with a fresh deque after a drain that observed a burst exceeding
+     * [GLOBAL_EFFECT_QUEUE_SHRINK_THRESHOLD] — [ArrayDeque] never shrinks its backing array on its
+     * own, so the deque would otherwise stay pinned at the peak size for the life of the runtime.
      */
-    private val globalEffectQueue = ArrayDeque<Effect>()
+    private var globalEffectQueue = ArrayDeque<Effect>(INITIAL_GLOBAL_EFFECT_QUEUE_CAPACITY)
+    private var globalEffectQueuePeakSize = 0
 
     /**
      * Determines if we are iterating through [globalEffectQueue]. It prevents us from
@@ -203,6 +216,8 @@ class FormulaRuntime<Input : Any, Output : Any>(
             for (index in effects.indices) {
                 globalEffectQueue.addLast(effects[index])
             }
+            val size = globalEffectQueue.size
+            if (size > globalEffectQueuePeakSize) globalEffectQueuePeakSize = size
         }
 
         pendingEvaluation = pendingEvaluation || evaluate
@@ -349,6 +364,10 @@ class FormulaRuntime<Input : Any, Output : Any>(
             }
             dispatcher.dispatch(effect)
         }
+        if (globalEffectQueuePeakSize > GLOBAL_EFFECT_QUEUE_SHRINK_THRESHOLD) {
+            globalEffectQueue = ArrayDeque(INITIAL_GLOBAL_EFFECT_QUEUE_CAPACITY)
+        }
+        globalEffectQueuePeakSize = 0
         isExecutingEffects = false
     }
 

--- a/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
+++ b/formula/src/main/java/com/instacart/formula/FormulaRuntime.kt
@@ -11,7 +11,6 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
-import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 import java.util.concurrent.atomic.AtomicReference
 import kotlin.coroutines.CoroutineContext
@@ -82,7 +81,7 @@ class FormulaRuntime<Input : Any, Output : Any>(
     /**
      * Global transition effect queue which executes side-effects after all formulas are idle.
      */
-    private val globalEffectQueue = LinkedList<Effect>()
+    private val globalEffectQueue = ArrayDeque<Effect>()
 
     /**
      * Determines if we are iterating through [globalEffectQueue]. It prevents us from
@@ -342,7 +341,7 @@ class FormulaRuntime<Input : Any, Output : Any>(
     private fun executeTransitionEffects() {
         isExecutingEffects = true
         while (globalEffectQueue.isNotEmpty()) {
-            val effect = globalEffectQueue.pollFirst()
+            val effect = globalEffectQueue.removeFirst()
             val dispatcher = when (effect.type) {
                 Effect.Unconfined -> Dispatcher.None
                 Effect.Main -> Dispatcher.Main

--- a/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
@@ -8,8 +8,14 @@ internal class BatchImpl internal constructor(
     private val key: Any,
 ) : BatchScheduler.Batch {
 
+    private companion object {
+        // BatchImpl is single-shot — the instance is discarded after execute() — so no shrink
+        // logic is needed. Initial capacity sized for the common small-batch case.
+        private const val INITIAL_UPDATES_CAPACITY = 4
+    }
+
     private val isScheduled = AtomicBoolean(false)
-    private val updates = ArrayDeque<() -> Unit>()
+    private val updates = ArrayDeque<() -> Unit>(INITIAL_UPDATES_CAPACITY)
 
     fun add(update: () -> Unit) {
         updates.addLast(update)

--- a/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/batch/BatchImpl.kt
@@ -1,6 +1,5 @@
 package com.instacart.formula.batch
 
-import java.util.LinkedList
 import java.util.concurrent.atomic.AtomicBoolean
 
 internal class BatchImpl internal constructor(
@@ -10,10 +9,10 @@ internal class BatchImpl internal constructor(
 ) : BatchScheduler.Batch {
 
     private val isScheduled = AtomicBoolean(false)
-    private val updates = LinkedList<() -> Unit>()
+    private val updates = ArrayDeque<() -> Unit>()
 
     fun add(update: () -> Unit) {
-        updates.add(update)
+        updates.addLast(update)
     }
 
     override fun execute() {

--- a/formula/src/main/java/com/instacart/formula/runtime/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/runtime/FormulaManagerImpl.kt
@@ -16,7 +16,6 @@ import com.instacart.formula.lifecycle.LifecycleScheduler
 import com.instacart.formula.lifecycle.ValidationException
 import com.instacart.formula.plugin.ChildAlreadyUsedException
 import com.instacart.formula.plugin.FormulaError
-import java.util.LinkedList
 
 /**
  * Responsible for keeping track of formula's state, running actions, and child formulas. The
@@ -69,7 +68,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
      * while [isRunning] is true. If [isRunning] is false, we will pass the transitions
      * to [ManagerDelegate].
      */
-    private val transitionQueue = LinkedList<DeferredTransition<*, *, *>>()
+    private val transitionQueue = ArrayDeque<DeferredTransition<*, *, *>>()
 
     fun canUpdatesContinue(evaluationId: Long): Boolean {
         return !isEvaluationNeeded(evaluationId) && transitionQueue.isEmpty()
@@ -307,7 +306,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
 
         // Execute deferred transitions
         while (transitionQueue.isNotEmpty()) {
-            transitionQueue.pollFirst().execute()
+            transitionQueue.removeFirst().execute()
         }
 
         inspector?.onFormulaFinished(formulaType)
@@ -381,7 +380,7 @@ internal class FormulaManagerImpl<Input, State, Output>(
      */
     private fun handleTransitionQueue(evaluationId: Long): Boolean {
         while (transitionQueue.isNotEmpty()) {
-            val event = transitionQueue.pollFirst()
+            val event = transitionQueue.removeFirst()
             event.execute()
             if (isEvaluationNeeded(evaluationId)) {
                 return true

--- a/formula/src/main/java/com/instacart/formula/runtime/FormulaManagerImpl.kt
+++ b/formula/src/main/java/com/instacart/formula/runtime/FormulaManagerImpl.kt
@@ -35,6 +35,14 @@ internal class FormulaManagerImpl<Input, State, Output>(
     EffectDelegate,
     LifecycleComponent {
 
+    private companion object {
+        // Most evaluations queue at most a handful of deferred transitions in flight.
+        private const val INITIAL_TRANSITION_QUEUE_CAPACITY = 4
+        // After a drain, replace the deque if we observed a burst this large. Long-lived
+        // formulas would otherwise pin the high-water capacity for their entire lifetime.
+        private const val TRANSITION_QUEUE_SHRINK_THRESHOLD = 32
+    }
+
     private val lifecycleCache = LifecycleCacheImpl(this)
     private var state: State = formula.initialState(initialInput)
     private var frame: Frame<Input, State, Output>? = null
@@ -66,9 +74,13 @@ internal class FormulaManagerImpl<Input, State, Output>(
     /**
      * Pending transition queue which will be populated and executed within [run] function
      * while [isRunning] is true. If [isRunning] is false, we will pass the transitions
-     * to [ManagerDelegate].
+     * to [ManagerDelegate]. Replaced with a fresh deque after a drain that observed a burst
+     * exceeding [TRANSITION_QUEUE_SHRINK_THRESHOLD] — [ArrayDeque] never shrinks its backing
+     * array on its own, so the deque would otherwise stay pinned at the peak size for the
+     * life of this formula manager.
      */
-    private val transitionQueue = ArrayDeque<DeferredTransition<*, *, *>>()
+    private var transitionQueue = ArrayDeque<DeferredTransition<*, *, *>>(INITIAL_TRANSITION_QUEUE_CAPACITY)
+    private var transitionQueuePeakSize = 0
 
     fun canUpdatesContinue(evaluationId: Long): Boolean {
         return !isEvaluationNeeded(evaluationId) && transitionQueue.isEmpty()
@@ -316,17 +328,23 @@ internal class FormulaManagerImpl<Input, State, Output>(
         if (terminated) {
             transition.execute()
         } else if (isRunning) {
-            transitionQueue.addLast(transition)
+            enqueueTransition(transition)
         } else {
             val lastFrame = frame
             if (lastFrame == null || isEvaluationNeeded(lastFrame.associatedEvaluationId)) {
                 // Since evaluation is already needed, we can wait for it to happen and
                 // then we'll execute the transition.
-                transitionQueue.addLast(transition)
+                enqueueTransition(transition)
             } else {
                 transition.execute()
             }
         }
+    }
+
+    private fun enqueueTransition(transition: DeferredTransition<*, *, *>) {
+        transitionQueue.addLast(transition)
+        val size = transitionQueue.size
+        if (size > transitionQueuePeakSize) transitionQueuePeakSize = size
     }
 
     override fun onPostTransition(effects: List<Effect>, evaluate: Boolean) {
@@ -386,7 +404,12 @@ internal class FormulaManagerImpl<Input, State, Output>(
                 return true
             }
         }
-
+        // Queue drained without forcing re-evaluation — safe point to reclaim the backing array
+        // if a burst pushed us past the shrink threshold.
+        if (transitionQueuePeakSize > TRANSITION_QUEUE_SHRINK_THRESHOLD) {
+            transitionQueue = ArrayDeque(INITIAL_TRANSITION_QUEUE_CAPACITY)
+        }
+        transitionQueuePeakSize = 0
         return false
     }
 


### PR DESCRIPTION
## Summary
- Replaces `LinkedList` with `ArrayDeque` in three remaining queue fields: `FormulaRuntime.globalEffectQueue`, `FormulaManagerImpl.transitionQueue`, and `BatchImpl.updates`.
- Continues the precedent from #497 ([Performance] Use ArrayDeque for startEffect), extending it to the rest of the runtime's queue allocations.

## Why
All three fields are used as FIFO queues — add-to-tail, remove-from-head, no random access, no mid-iteration mutation. `ArrayDeque` is strictly better for this workload:
- Backed by a single circular array → much better cache locality than `LinkedList`'s per-element heap-allocated `Node`s.
- No allocation per add (amortized O(1) when the backing array has room).
- Same O(1) add/remove at both ends.

## Compatibility notes
- All three fields are `private`, so no external API change.
- `pollFirst()` calls were switched to `removeFirst()` — every call site is already guarded by `isNotEmpty()`, so the throw-vs-return-null difference is not observable.
- `BatchImpl.updates` is still passed as `List<() -> Unit>` to `BatchManager.Executor.executeBatch`; `ArrayDeque` implements `MutableList`, so this is unchanged.
- `LinkedList` allowed mid-iteration mutation via `ListIterator`; `ArrayDeque` throws `ConcurrentModificationException`. None of the affected code paths use iterators — they all drain via `removeFirst()` in a `while (isNotEmpty())` loop, which works the same on both.

## Test plan
- [x] `./gradlew :formula:test` passes locally.
- [ ] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)