### PR TITLE
Fix flake in multi-thread handoff test

### DIFF
--- a/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
+++ b/formula/src/test/java/com/instacart/formula/FormulaRuntimeTest.kt
@@ -2048,7 +2048,10 @@ class FormulaRuntimeTest {
     @Test
     fun `formula multi-thread handoff to executing thread`() = runTest {
         with(MultiThreadRobot(this)) {
-            thread("thread-a", 50)
+            // Wait until thread-a has claimed the SynchronizedUpdateQueue before submitting
+            // thread-b, otherwise the two executor threads race for the takeOver CAS and the
+            // assertion below (which hard-codes thread-a as the executing thread) flakes.
+            thread("thread-a", 50, awaitTakeOver = true)
             thread("thread-b", 10)
             awaitCompletion()
             thread("thread-b", 10)

--- a/formula/src/test/java/com/instacart/formula/subjects/MultiThreadRobot.kt
+++ b/formula/src/test/java/com/instacart/formula/subjects/MultiThreadRobot.kt
@@ -1,9 +1,12 @@
 package com.instacart.formula.subjects
 
 import com.google.common.truth.Truth
+import com.instacart.formula.plugin.Inspector
 import com.instacart.formula.subjects.SleepFormula.SleepEvent
 import com.instacart.formula.test.test
 import kotlinx.coroutines.CoroutineScope
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.CountDownLatch
 import java.util.concurrent.Executor
 import java.util.concurrent.Executors
 import java.util.concurrent.ThreadFactory
@@ -16,23 +19,53 @@ class MultiThreadRobot(scope: CoroutineScope) {
         }
     }
 
+    // Latches that fire when the named thread's onSleep transition is observed by the
+    // inspector. The inspector callback runs synchronously inside SynchronizedUpdateQueue's
+    // takeOver, so a countdown proves threadRunning == that thread.
+    private val takeOverLatches = ConcurrentHashMap<String, CountDownLatch>()
+
+    private val takeOverInspector = object : Inspector {
+        override fun onStateChanged(formulaType: Class<*>, event: Any?, old: Any?, new: Any?) {
+            val pending = (new as? SleepFormula.State)?.pendingEvent ?: return
+            takeOverLatches.remove(pending.threadName)?.countDown()
+        }
+    }
+
     private val threadFormula = SleepFormula()
-    private val observer = threadFormula.test(scope).input("initial-key")
+    private val observer = threadFormula.test(scope, inspector = takeOverInspector).input("initial-key")
 
     // Manage executors
     private val executorMap = mutableMapOf<String, Executor>()
     private var expectedEventCount = 0
 
-    fun thread(name: String, sleepDuration: Long) = apply {
+    /**
+     * Submits a sleep event on [name].
+     *
+     * Set [awaitTakeOver] to true to block until this thread has actually claimed the
+     * SynchronizedUpdateQueue — useful for tests that need a deterministic ordering of
+     * which thread becomes the executing thread before another thread enqueues work.
+     */
+    fun thread(name: String, sleepDuration: Long, awaitTakeOver: Boolean = false) = apply {
         expectedEventCount++
         val executor = executorMap.getOrPut(name) {
             Executors.newSingleThreadExecutor(NamedThreadFactory(name))
+        }
+
+        val latch = if (awaitTakeOver) {
+            CountDownLatch(1).also { takeOverLatches[name] = it }
+        } else {
+            null
         }
 
         executor.execute {
             observer.output {
                 this.onSleep(sleepDuration)
             }
+        }
+
+        if (latch != null && !latch.await(5, TimeUnit.SECONDS)) {
+            takeOverLatches.remove(name)
+            throw IllegalStateException("Timeout waiting for thread $name to take over the queue")
         }
     }
 


### PR DESCRIPTION
## Summary

The test `formula multi-thread handoff to executing thread` was flaky (~10-30% failure rate). It submitted work to two single-thread executors back-to-back and assumed `thread-a` would always win the `SynchronizedUpdateQueue` takeOver CAS — but there was no synchronization forcing that ordering, so sometimes `thread-b` won the race instead:

```
expected: [(50, thread-a), (10, thread-a), (10, thread-b)]
but was : [(10, thread-b), (50, thread-b), (10, thread-b)]
```

This adds an `awaitTakeOver` option to `MultiThreadRobot.thread()` that blocks until the named thread has actually claimed the queue. Detection uses an `Inspector` — `onStateChanged` fires synchronously inside the listener, which itself runs inside `takeOver`, so observing the state change with `pendingEvent.threadName == name` proves that thread owns `threadRunning`. Once `thread-a` holds the queue, `thread-b`'s submission is guaranteed to be enqueued behind it.

No production code changed — only the test helper and the one assertion that depended on the racy ordering.

## Test plan

- [x] Ran the previously-flaky test 20 consecutive times — all pass
- [x] Ran the two other `MultiThreadRobot`-based tests (`formula multi-threaded events fired at the same time`, `formula multi-threaded input after termination`) — still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)